### PR TITLE
Return DNSZone object in create_dns_zone

### DIFF
--- a/infoblox_client/object_manager.py
+++ b/infoblox_client/object_manager.py
@@ -246,15 +246,15 @@ class InfobloxObjectManager(object):
                         zone_format=None, ns_group=None, prefix=None,
                         extattrs=None):
         try:
-            obj.DNSZone.create(self.connector,
-                               fqdn=dns_zone,
-                               view=dns_view,
-                               extattrs=extattrs,
-                               zone_format=zone_format,
-                               ns_group=ns_group,
-                               prefix=prefix,
-                               grid_primary=grid_primary,
-                               grid_secondaries=grid_secondaries)
+            return obj.DNSZone.create(self.connector,
+                                      fqdn=dns_zone,
+                                      view=dns_view,
+                                      extattrs=extattrs,
+                                      zone_format=zone_format,
+                                      ns_group=ns_group,
+                                      prefix=prefix,
+                                      grid_primary=grid_primary,
+                                      grid_secondaries=grid_secondaries)
         except ib_ex.InfobloxCannotCreateObject:
             LOG.warning('Unable to create DNS zone %(dns_zone_fqdn)s '
                         'for %(dns_view)s',

--- a/infoblox_client/tests/unit/test_object_manager.py
+++ b/infoblox_client/tests/unit/test_object_manager.py
@@ -591,8 +591,9 @@ class ObjectManipulatorTestCase(base.TestCase):
 
         ibom = om.InfobloxObjectManager(connector)
 
-        ibom.create_dns_zone(dns_view_name, fqdn, primary_dns_members,
-                             secondary_dns_members, zone_format=zone_format)
+        zone = ibom.create_dns_zone(dns_view_name, fqdn, primary_dns_members,
+                                    secondary_dns_members,
+                                    zone_format=zone_format)
 
         matcher = PayloadMatcher({'view': dns_view_name,
                                   'fqdn': fqdn})
@@ -610,6 +611,7 @@ class ObjectManipulatorTestCase(base.TestCase):
                    }
         connector.create_object.assert_called_once_with('zone_auth', payload,
                                                         mock.ANY)
+        self.assertIsInstance(zone, objects.DNSZone)
 
     def test_create_dns_zone_creates_zone_auth_object(self):
         dns_view_name = 'dns-view-name'


### PR DESCRIPTION
DNSZone returned None independently from success or fail
of create request.
Updated code to return DNSZone object on successfull zone creation.
Closes #5.