### PR TITLE
Add utility to determine supported feature

### DIFF
--- a/infoblox_client/connector.py
+++ b/infoblox_client/connector.py
@@ -13,7 +13,6 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-from __future__ import absolute_import
 import functools
 import re
 import requests

--- a/infoblox_client/feature.py
+++ b/infoblox_client/feature.py
@@ -1,0 +1,107 @@
+# Copyright 2015 Infoblox Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import six
+import string
+
+from infoblox_client import exceptions as ib_ex
+
+FEATURE_VERSIONS = {
+    'create_ea_def': '2.2',
+    'cloud_api': '2.0',
+    'member_ipv6_setting': '2.0',
+    'member_licenses': '2.0',
+    'enable_member_dns': '2.2.1',
+    'enable_member_dhcp': '2.2.1'}
+
+
+class Feature(object):
+    """Class representing available NIOS features
+
+    Based on the following:
+      - Infoblox WAPI Version
+      - Known features and corresponding WAPI version requirement
+    the Feature class represents available NIOS features as attributes.
+    """
+    def __init__(self, version, feature_versions=None):
+        self._wapi_version = None
+
+        if feature_versions is None:
+            feature_versions = FEATURE_VERSIONS
+
+        if isinstance(version, six.string_types):
+            wapi_version = version
+        elif hasattr(version, 'wapi_version'):
+            wapi_version = getattr(version, 'wapi_version')
+        else:
+            msg = "WAPI version cannot be determined from '%s'" % version
+            raise ib_ex.InfobloxConfigException(msg=msg)
+
+        wapi_util = WapiVersionUtil(wapi_version)
+        for f, v in feature_versions.items():
+            setattr(self,
+                    f,
+                    wapi_util.is_version_supported(v))
+
+
+class WapiVersionUtil(object):
+    """Provide utility functions for manipulating WAPI version
+
+    Provide methods that manipulate and get information from
+    WAPI version string.
+    """
+    def __init__(self, version):
+        self._version_parts = self._get_wapi_version_parts(version)
+
+    @property
+    def version_parts(self):
+        return self._version_parts
+
+    @property
+    def major_version(self):
+        return self.version_parts[0]
+
+    @property
+    def minor_version(self):
+        return self.version_parts[1]
+
+    @property
+    def patch_version(self):
+        return self.version_parts[2]
+
+    def is_version_supported(self, req_ver):
+        req_parts = WapiVersionUtil(req_ver).version_parts
+
+        for a, b in zip(self.version_parts, req_parts):
+            if a is None:
+                return True if b is None else False
+            elif b is None:
+                return True
+            elif not a == b:
+                return (a > b)
+        return True
+
+    @staticmethod
+    def _get_wapi_version_parts(version):
+        parts = version.split('.')
+        if (not parts or len(parts) > 3 or len(parts) < 2):
+            raise ValueError("Invalid argument was passed")
+        for p in parts:
+            if not len(p) or p not in string.digits:
+                raise ValueError("Invalid argument was passed")
+        parts = [int(x) for x in parts]
+        if len(parts) == 2:
+            parts.append(None)
+        return parts

--- a/infoblox_client/tests/unit/test_feature.py
+++ b/infoblox_client/tests/unit/test_feature.py
@@ -1,0 +1,139 @@
+# Copyright 2015 Infoblox Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import mock
+
+from infoblox_client import feature
+from infoblox_client.tests import base
+
+
+class TestFeature(base.TestCase):
+
+    def test_wapi_version_util(self):
+        wapi1 = feature.WapiVersionUtil('2.3')
+        self.assertEqual(2, wapi1.major_version)
+        self.assertEqual(3, wapi1.minor_version)
+        self.assertEqual(None, wapi1.patch_version)
+
+        wapi2 = feature.WapiVersionUtil('2.2.3')
+        self.assertEqual(2, wapi2.major_version)
+        self.assertEqual(2, wapi2.minor_version)
+        self.assertEqual(3, wapi2.patch_version)
+
+        wapi3 = feature.WapiVersionUtil('2.2')
+        self.assertEqual(True, wapi3.is_version_supported('2.1'))
+        self.assertEqual(True, wapi3.is_version_supported('1.3'))
+        self.assertEqual(True, wapi3.is_version_supported('2.2'))
+        self.assertEqual(False, wapi3.is_version_supported('2.3'))
+        self.assertEqual(False, wapi3.is_version_supported('3.1'))
+        self.assertEqual(False, wapi3.is_version_supported('2.2.1'))
+
+        wapi3 = feature.WapiVersionUtil('2.3.4')
+        self.assertEqual(True, wapi3.is_version_supported('2.1'))
+        self.assertEqual(True, wapi3.is_version_supported('1.5'))
+        self.assertEqual(True, wapi3.is_version_supported('2.3'))
+        self.assertEqual(True, wapi3.is_version_supported('2.3.3'))
+        self.assertEqual(True, wapi3.is_version_supported('2.3.4'))
+        self.assertEqual(False, wapi3.is_version_supported('2.4'))
+        self.assertEqual(False, wapi3.is_version_supported('3.1'))
+        self.assertEqual(False, wapi3.is_version_supported('2.3.5'))
+
+        self.assertRaises(ValueError, feature.WapiVersionUtil, ' ')
+        self.assertRaises(ValueError, feature.WapiVersionUtil, '2.')
+        self.assertRaises(ValueError, feature.WapiVersionUtil, '.')
+        self.assertRaises(ValueError, feature.WapiVersionUtil, '.2')
+        self.assertRaises(ValueError, feature.WapiVersionUtil, '1.2.3.4')
+
+    def test_features(self):
+        feature_versions = {
+            'ea_def_creation': '2.2',
+            'cloud_api': '2.0',
+            'enable_member_dns': '2.2.1'}
+
+        my_feature1 = feature.Feature('2.2', feature_versions)
+        self.assertEqual(True, my_feature1.ea_def_creation)
+        self.assertEqual(True, my_feature1.cloud_api)
+        self.assertEqual(False, my_feature1.enable_member_dns)
+
+        my_feature2 = feature.Feature('2.0', feature_versions)
+        self.assertEqual(False, my_feature2.ea_def_creation)
+        self.assertEqual(True, my_feature2.cloud_api)
+        self.assertEqual(False, my_feature2.enable_member_dns)
+
+        my_feature3 = feature.Feature('1.6', feature_versions)
+        self.assertEqual(False, my_feature3.ea_def_creation)
+        self.assertEqual(False, my_feature3.cloud_api)
+        self.assertEqual(False, my_feature3.enable_member_dns)
+
+        my_feature4 = feature.Feature('2.2.2', feature_versions)
+        self.assertEqual(True, my_feature4.ea_def_creation)
+        self.assertEqual(True, my_feature4.cloud_api)
+        self.assertEqual(True, my_feature4.enable_member_dns)
+
+        my_feature5 = feature.Feature('2.2.0', feature_versions)
+        self.assertEqual(True, my_feature5.ea_def_creation)
+        self.assertEqual(True, my_feature5.cloud_api)
+        self.assertEqual(False, my_feature5.enable_member_dns)
+
+        my_feature6 = feature.Feature('2.2.1', feature_versions)
+        self.assertEqual(True, my_feature6.ea_def_creation)
+        self.assertEqual(True, my_feature6.cloud_api)
+        self.assertEqual(True, my_feature6.enable_member_dns)
+
+    def _mock_connector(self, wapi_version):
+        connector = mock.Mock(wapi_version=wapi_version)
+        return connector
+
+    def test_features_with_connector(self):
+        feature_versions = {
+            'ea_def_creation': '2.2',
+            'cloud_api': '2.0',
+            'enable_member_dns': '2.2.1'}
+
+        connector1 = self._mock_connector('2.2')
+        my_feature1 = feature.Feature(connector1, feature_versions)
+        self.assertEqual(True, my_feature1.ea_def_creation)
+        self.assertEqual(True, my_feature1.cloud_api)
+        self.assertEqual(False, my_feature1.enable_member_dns)
+
+        connector2 = self._mock_connector('2.0')
+        my_feature2 = feature.Feature(connector2, feature_versions)
+        self.assertEqual(False, my_feature2.ea_def_creation)
+        self.assertEqual(True, my_feature2.cloud_api)
+        self.assertEqual(False, my_feature2.enable_member_dns)
+
+        connector3 = self._mock_connector('1.6')
+        my_feature3 = feature.Feature(connector3, feature_versions)
+        self.assertEqual(False, my_feature3.ea_def_creation)
+        self.assertEqual(False, my_feature3.cloud_api)
+        self.assertEqual(False, my_feature3.enable_member_dns)
+
+        connector4 = self._mock_connector('2.2.2')
+        my_feature4 = feature.Feature(connector4, feature_versions)
+        self.assertEqual(True, my_feature4.ea_def_creation)
+        self.assertEqual(True, my_feature4.cloud_api)
+        self.assertEqual(True, my_feature4.enable_member_dns)
+
+        connector5 = self._mock_connector('2.2.0')
+        my_feature5 = feature.Feature(connector5, feature_versions)
+        self.assertEqual(True, my_feature5.ea_def_creation)
+        self.assertEqual(True, my_feature5.cloud_api)
+        self.assertEqual(False, my_feature5.enable_member_dns)
+
+        connector6 = self._mock_connector('2.2.1')
+        my_feature6 = feature.Feature(connector6, feature_versions)
+        self.assertEqual(True, my_feature6.ea_def_creation)
+        self.assertEqual(True, my_feature6.cloud_api)
+        self.assertEqual(True, my_feature6.enable_member_dns)


### PR DESCRIPTION
Added Feature class that is used to determine Infoblox features
supported by a WAPI version.


Please comment:
I am not sure that FEATURE_VERSIONS belong to infoblox-client. The code is cleaner as it is.
But I feel like FEATURE_VERSIONS should belong to networking-infoblox constants.py.
Recommendations please.