### PR TITLE
Prevent sending host field on IP update

### DIFF
--- a/infoblox_client/objects.py
+++ b/infoblox_client/objects.py
@@ -565,7 +565,7 @@ class SubObjects(BaseObject):
 
 class IP(SubObjects):
     _fields = []
-    _shadow_fields = ['_ref', 'ip']
+    _shadow_fields = ['_ref', 'ip', 'host']
     _remap = {}
     ip_version = None
 
@@ -609,13 +609,13 @@ class IP(SubObjects):
 
 
 class IPv4(IP):
-    _fields = ['ipv4addr', 'configure_for_dhcp', 'host', 'mac']
+    _fields = ['ipv4addr', 'configure_for_dhcp',  'mac']
     _remap = {'ipv4addr': 'ip'}
     ip_version = 4
 
 
 class IPv6(IP):
-    _fields = ['ipv6addr', 'configure_for_dhcp', 'host', 'duid']
+    _fields = ['ipv6addr', 'configure_for_dhcp', 'duid']
     _remap = {'ipv6addr': 'ip'}
     ip_version = 6
 

--- a/infoblox_client/tests/unit/test_objects.py
+++ b/infoblox_client/tests/unit/test_objects.py
@@ -134,6 +134,19 @@ class TestObjects(base.TestCase):
                          nios_ip.host)
         self.assertEqual(mock_record['ipv4addrs'][0]['configure_for_dhcp'],
                          nios_ip.configure_for_dhcp)
+        # Validate 'host' field is not send on update
+        new_ip = objects.IP.create(ip='22.0.0.10', mac='fa:16:3e:29:87:71',
+                                   configure_for_dhcp=False)
+        host_record.ip.append(new_ip)
+        host_record.extattrs = {}
+        host_record.update()
+        ip_dict['configure_for_dhcp'] = False
+        ip_dict_new = {'ipv4addr': '22.0.0.10', 'mac': 'fa:16:3e:29:87:71',
+                       'configure_for_dhcp': False}
+        connector.update_object.assert_called_once_with(
+            host_record.ref,
+            {'ipv4addrs': [ip_dict, ip_dict_new],
+             'extattrs': {}}, mock.ANY)
 
     def test_search_and_delete_host_record(self):
         host_record_copy = copy.deepcopy(DEFAULT_HOST_RECORD)


### PR DESCRIPTION
'host' field is not writtable in IP object, but it was send to NIOS
on adding new ip to existent HostRecord.
To prevent sending 'host' field to NIOS it was moved to _shadow_fields.
So it exists in object, but not send on via API on object updates.

Closes: #18