### PR TITLE
Raise exception with details if reply is not json

### DIFF
--- a/infoblox_client/connector.py
+++ b/infoblox_client/connector.py
@@ -166,6 +166,17 @@ class Connector(object):
             opts['data'] = jsonutils.dumps(data)
         return opts
 
+    @staticmethod
+    def _parse_reply(request):
+        """Tries to parse reply from NIOS.
+
+        Raises exception with content if reply is not in json format
+        """
+        try:
+            return jsonutils.loads(request.content)
+        except ValueError:
+            raise ib_ex.InfobloxConnectionError(reason=request.content)
+
     @reraise_neutron_exception
     def get_object(self, obj_type, payload=None, return_fields=None,
                    extattrs=None, force_proxy=False):
@@ -228,7 +239,7 @@ class Connector(object):
                 content=r.content,
                 code=r.status_code)
 
-        return jsonutils.loads(r.content)
+        return self._parse_reply(r)
 
     @reraise_neutron_exception
     def create_object(self, obj_type, payload, return_fields=None):
@@ -262,7 +273,7 @@ class Connector(object):
                 args=payload,
                 code=r.status_code)
 
-        return jsonutils.loads(r.content)
+        return self._parse_reply(r)
 
     @reraise_neutron_exception
     def call_func(self, func_name, ref, payload, return_fields=None):
@@ -284,7 +295,7 @@ class Connector(object):
                 content=r.content,
                 code=r.status_code)
 
-        return jsonutils.loads(r.content)
+        return self._parse_reply(r)
 
     @reraise_neutron_exception
     def update_object(self, ref, payload, return_fields=None):
@@ -312,7 +323,7 @@ class Connector(object):
                 content=r.content,
                 code=r.status_code)
 
-        return jsonutils.loads(r.content)
+        return self._parse_reply(r)
 
     @reraise_neutron_exception
     def delete_object(self, ref):
@@ -337,7 +348,7 @@ class Connector(object):
                 content=r.content,
                 code=r.status_code)
 
-        return jsonutils.loads(r.content)
+        return self._parse_reply(r)
 
     @staticmethod
     def is_cloud_wapi(wapi_version):

--- a/infoblox_client/tests/unit/test_connector.py
+++ b/infoblox_client/tests/unit/test_connector.py
@@ -299,3 +299,26 @@ class TestInfobloxConnectorStaticMethods(base.TestCase):
             self.assertRaises(ValueError,
                               connector.Connector.is_cloud_wapi,
                               value)
+
+    def test__parse_reply_raises_connection_error(self):
+        request = mock.Mock()
+        request.content = ('<HTML><BODY BGCOLOR="FFFFFF">'
+                           'Some error reply</BODY></HTML>\n')
+        self.assertRaises(exceptions.InfobloxConnectionError,
+                          connector.Connector._parse_reply,
+                          request)
+
+    def test__parse_reply(self):
+        request = mock.Mock()
+        request.content = (
+            '[{"_ref": "network/ZG5zLm5ldHdvcmskMTAuNDAuMjUuMC8yNC8w:'
+            '10.40.25.0/24/default","network": "10.40.25.0/24",'
+            '"network_view": "default"}]')
+        expected_reply = [
+            {'_ref': "network/ZG5zLm5ldHdvcmskMTAuNDAuMjUuMC8yNC8w"
+                     ":10.40.25.0/24/default",
+             'network': "10.40.25.0/24",
+             'network_view': "default"}]
+
+        parsed_reply = connector.Connector._parse_reply(request)
+        self.assertEqual(expected_reply, parsed_reply)


### PR DESCRIPTION
Previously if NIOS reply was not in json format ValueError was raised from
json library, and reply itself was not logged.
Typically if reply is not in json format it indicates some error response.
Updated reply parsing to raise an exception with reply details
if reply is not json format.

Closes: #25