### PR TITLE
Add 'silent_ssl_warnings' option to connector

### DIFF
--- a/infoblox_client/connector.py
+++ b/infoblox_client/connector.py
@@ -52,6 +52,7 @@ class Connector(object):
 
     DEFAULT_HEADER = {'Content-type': 'application/json'}
     DEFAULT_OPTIONS = {'ssl_verify': False,
+                       'silent_ssl_warnings': False,
                        'http_request_timeout': 10,
                        'http_pool_connections': 10,
                        'http_pool_maxsize': 10,
@@ -74,7 +75,8 @@ class Connector(object):
         """Copy needed options to self"""
         attributes = ('host', 'wapi_version', 'username', 'password',
                       'ssl_verify', 'http_request_timeout',
-                      'http_pool_connections', 'http_pool_maxsize')
+                      'http_pool_connections', 'http_pool_maxsize',
+                      'silent_ssl_warnings')
         for attr in attributes:
             if isinstance(options, dict) and attr in options:
                 setattr(self, attr, options[attr])
@@ -105,6 +107,9 @@ class Connector(object):
         self.session.mount('https://', adapter)
         self.session.auth = (self.username, self.password)
         self.session.verify = self.ssl_verify
+
+        if self.silent_ssl_warnings:
+            requests.packages.urllib3.disable_warnings()
 
     def _construct_url(self, relative_path, query_params=None,
                        extattrs=None, force_proxy=False):

--- a/infoblox_client/tests/unit/test_connector.py
+++ b/infoblox_client/tests/unit/test_connector.py
@@ -41,6 +41,7 @@ class TestInfobloxConnector(base.TestCase):
         opts.username = 'admin'
         opts.password = 'password'
         opts.ssl_verify = False
+        opts.silent_ssl_warnings = True
         opts.http_pool_connections = 10
         opts.http_pool_maxsize = 10
         opts.http_request_timeout = 10
@@ -252,6 +253,7 @@ class TestInfobloxConnectorStaticMethods(base.TestCase):
                     username='admin',
                     password='password',
                     ssl_verify=False,
+                    silent_ssl_warnings=True,
                     http_pool_connections=10,
                     http_pool_maxsize=10,
                     http_request_timeout=10)
@@ -261,6 +263,8 @@ class TestInfobloxConnectorStaticMethods(base.TestCase):
         self.assertEqual(opts['username'], conn.username)
         self.assertEqual(opts['password'], conn.password)
         self.assertEqual(opts['ssl_verify'], conn.ssl_verify)
+        self.assertEqual(opts['silent_ssl_warnings'],
+                         conn.silent_ssl_warnings)
         self.assertEqual(opts['http_pool_connections'],
                          conn.http_pool_connections)
         self.assertEqual(opts['http_pool_maxsize'], conn.http_pool_maxsize)
@@ -279,6 +283,7 @@ class TestInfobloxConnectorStaticMethods(base.TestCase):
                     password='password')
         conn = connector.Connector(opts)
         self.assertEqual(False, conn.ssl_verify)
+        self.assertEqual(False, conn.silent_ssl_warnings)
         self.assertEqual(10, conn.http_request_timeout)
         self.assertEqual(10, conn.http_pool_connections)
         self.assertEqual(10, conn.http_pool_maxsize)


### PR DESCRIPTION
If 'ssl_verify' is set to False, then each api request generates ssl
warnings.
Added new option for connector to be able to disable these warnings.
By default this option is turned off.
This option is not expected to be used in production, as well as
'ssl_verify' = False, so make sure 'silent_ssl_warnings' usage is
limited with development/test environments.

Note: warnings are disabled on urllib3 level, so it affects all
instanses of requests as a result. Use with option cautiously.

Closes: #22