### PR TITLE
Do not search IPRange before creating

### DIFF
--- a/infoblox_client/object_manager.py
+++ b/infoblox_client/object_manager.py
@@ -87,13 +87,15 @@ class InfobloxObjectManager(object):
 
     def create_ip_range(self, network_view, start_ip, end_ip, network,
                         disable, range_extattrs):
+        """Creates IPRange or fails if already exists."""
         return obj.IPRange.create(self.connector,
                                   network_view=network_view,
                                   start_addr=start_ip,
                                   end_addr=end_ip,
                                   cidr=network,
                                   disable=disable,
-                                  extattrs=range_extattrs)
+                                  extattrs=range_extattrs,
+                                  check_if_exists=False)
 
     def delete_ip_range(self, network_view, start_ip, end_ip):
         range = obj.IPRange.search(self.connector,

--- a/infoblox_client/tests/unit/test_object_manager.py
+++ b/infoblox_client/tests/unit/test_object_manager.py
@@ -282,7 +282,8 @@ class ObjectManagerTestCase(base.TestCase):
         ibom.create_ip_range(net_view, start_ip, end_ip, None, disable,
                              self.EXT_ATTRS)
 
-        assert connector.get_object.called
+        # Validate that IPRange is created without searching it first
+        assert not connector.get_object.called
         matcher = PayloadMatcher({'start_addr': start_ip,
                                   'end_addr': end_ip,
                                   'network_view': net_view,


### PR DESCRIPTION
Searching IPRange before creating suffers from synchronization delay
in GM+CPM environment [1].
But if search step is ommitted create IPRange request is proxified to
correct CPM member.

Updated object_manager to do not check for IPRange existence before
creating it.

[1] https://jira.inca.infoblox.com/browse/OPENSTACK-724