### PR TITLE
Add 'network' field to ip versioned fields

### DIFF
--- a/infoblox_client/objects.py
+++ b/infoblox_client/objects.py
@@ -315,7 +315,7 @@ class InfobloxObject(BaseObject):
         if cls._ip_version:
             return cls
 
-        for field in ['ip', 'cidr', 'start_ip', 'ip_address']:
+        for field in ['ip', 'cidr', 'start_ip', 'ip_address', 'network']:
             if field in kwargs:
                 if ib_utils.determine_ip_version(kwargs[field]) == 6:
                     return cls.get_v6_class()

--- a/infoblox_client/tests/unit/test_objects.py
+++ b/infoblox_client/tests/unit/test_objects.py
@@ -72,6 +72,17 @@ class TestObjects(base.TestCase):
             {'network_view': 'some-view', 'network': 'fffe:2312::/64'},
             extattrs=None, force_proxy=False, return_fields=mock.ANY)
 
+    def test_search_network_v6_using_network_field(self):
+        connector = self._mock_connector()
+
+        objects.Network.search(connector,
+                               network_view='some-view',
+                               network='fffe:2312::/64')
+        connector.get_object.assert_called_once_with(
+            'ipv6network',
+            {'network_view': 'some-view', 'network': 'fffe:2312::/64'},
+            extattrs=None, force_proxy=False, return_fields=mock.ANY)
+
     def test_search_network_with_results(self):
         found = {"_ref": "network/ZG5zLm5ldHdvcmskMTAuMzkuMTEuMC8yNC8w"
                          ":10.39.11.0/24/default",


### PR DESCRIPTION
IP version detection worked incorrectly if address is passes in
'network' field.
But worked fine if 'cidr' field is used.

Added 'network' field to list of fields that are used to detect needed
class version.

Closes: #30