### PR TITLE
Skip adding DHCP options for IPv6

### DIFF
--- a/infoblox_client/object_manager.py
+++ b/infoblox_client/object_manager.py
@@ -57,14 +57,18 @@ class InfobloxObjectManager(object):
                        network_extattrs=None):
         """Create NIOS Network."""
 
+        # NIOS does not allow to set Dhcp options for IPv6 over WAPI,
+        # so limit options usage with IPv4 only
+        ipv4 = ib_utils.determine_ip_version(cidr) == 4
+
         options = []
-        if nameservers:
+        if ipv4 and nameservers:
             options.append(obj.DhcpOption(name='domain-name-servers',
                                           value=",".join(nameservers)))
-        if gateway_ip:
+        if ipv4 and gateway_ip:
             options.append(obj.DhcpOption(name='routers',
                                           value=gateway_ip))
-        if dhcp_trel_ip:
+        if ipv4 and dhcp_trel_ip:
             options.append(obj.DhcpOption(name='dhcp-server-identifier',
                                           num=54,
                                           value=dhcp_trel_ip))


### PR DESCRIPTION
NIOS does not allow to set DHCP options for IPv6 over WAPI on network
creation and raises:
IBDataConflictError: IB.Data.Conflict:Set the option DHCP.routers from
the General Properties section.

So skipping setting DHCP options for IPv6.

Reported issue to NIOS: "Unable to create IPv6 network over WAPI if 'routers' is in options"
https://jira.inca.infoblox.com/browse/WEBAPI-543