### PR TITLE
Log all api calls in connector on debug level

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,6 +28,14 @@ Install infoblox-client using pip:
 Usage
 -----
 
+Configure logger prior to loading infoblox_client to get all debug messages in console:
+
+::
+
+  import logging
+  logging.basicConfig(level=logging.DEBUG)
+
+
 1. Low level API, using connector module.
 
 Retrieve list of network views from NIOS:


### PR DESCRIPTION
Added logging of each API call in connector with debug log level.
Reuses neutron logger from neutron if executed in neutron context.

Known limitations:
Infoblox-client is external package for neutron, so debug messages from
this package are not included in default neutron logger output even if
it is set to debug log level.

Closes: #24