### PR TITLE
Remove network_exists and change get_network

### DIFF
--- a/infoblox_client/object_manager.py
+++ b/infoblox_client/object_manager.py
@@ -81,13 +81,9 @@ class InfobloxObjectManager(object):
                                   check_if_exists=False)
 
     def get_network(self, network_view, cidr):
-        network = obj.Network.search(self.connector,
-                                     network_view=network_view,
-                                     cidr=cidr)
-        if not network:
-            raise ib_ex.InfobloxNetworkNotAvailable(
-                network_view=network_view, cidr=cidr)
-        return network
+        return obj.Network.search(self.connector,
+                                  network_view=network_view,
+                                  cidr=cidr)
 
     def create_ip_range(self, network_view, start_ip, end_ip, network,
                         disable, range_extattrs):
@@ -116,15 +112,6 @@ class InfobloxObjectManager(object):
             return bool(networks)
         except ib_ex.InfobloxSearchError:
             return False
-
-    def network_exists(self, network_view, cidr):
-        try:
-            network = obj.Network.search(self.connector,
-                                         network_view=network_view,
-                                         cidr=cidr)
-        except ib_ex.InfobloxSearchError:
-            network = None
-        return network is not None
 
     def delete_network(self, network_view, cidr):
         network = obj.Network.search(self.connector,

--- a/infoblox_client/tests/unit/test_object_manager.py
+++ b/infoblox_client/tests/unit/test_object_manager.py
@@ -182,26 +182,6 @@ class ObjectManagerTestCase(base.TestCase):
             'network', matcher, extattrs=None,
             force_proxy=mock.ANY, return_fields=mock.ANY)
 
-    def test_throws_network_not_available_on_get_network(self):
-        connector = mock.Mock()
-        connector.get_object.return_value = None
-
-        ibom = om.InfobloxObjectManager(connector)
-
-        net_view_name = 'test_dns_view_name'
-        cidr = '192.168.0.0/24'
-
-        self.assertRaises(exceptions.InfobloxNetworkNotAvailable,
-                          ibom.get_network, net_view_name, cidr)
-
-        matcher = PayloadMatcher({'network_view': net_view_name,
-                                  'network': cidr})
-        connector.get_object.assert_called_once_with('network',
-                                                     matcher,
-                                                     extattrs=mock.ANY,
-                                                     force_proxy=mock.ANY,
-                                                     return_fields=mock.ANY)
-
     def test_object_is_not_created_if_already_exists(self):
         net_view_name = 'test_dns_view_name'
         connector = mock.Mock()
@@ -471,22 +451,6 @@ class ObjectManagerTestCase(base.TestCase):
         result = ibom.has_networks(net_view_name)
 
         matcher = PayloadMatcher({'network_view': net_view_name})
-        connector.get_object.assert_called_once_with(
-            'network', matcher, return_fields=mock.ANY,
-            force_proxy=mock.ANY, extattrs=None)
-        self.assertEqual(False, result)
-
-    def test_network_exists(self):
-        connector = mock.Mock()
-        connector.get_object.return_value = None
-        ibom = om.InfobloxObjectManager(connector)
-        net_view_name = 'some-view'
-        cidr = '192.168.1.0/24'
-
-        result = ibom.network_exists(net_view_name, cidr)
-
-        matcher = PayloadMatcher({'network_view': net_view_name,
-                                  'network': cidr})
         connector.get_object.assert_called_once_with(
             'network', matcher, return_fields=mock.ANY,
             force_proxy=mock.ANY, extattrs=None)


### PR DESCRIPTION
Network_exists method was quite ineffective way of checking network
existence. It does not return network, so if any action has to
be performed on network then new API call has to be done to get network.
Using get_network instead is more effective, it returns None is no
network was found, or Network object if it exists.

Also get_network was updated to do not throw exception if no network is
found, so just None is returned.

Closes: #37