### PR TITLE
Fix error handling in create_object

### DIFF
--- a/infoblox_client/connector.py
+++ b/infoblox_client/connector.py
@@ -287,7 +287,7 @@ class Connector(object):
         if r.status_code != requests.codes.CREATED:
             response = utils.safe_json_load(r.content)
             already_assigned = 'is assigned to another network view'
-            if (response and already_assigned in response.text):
+            if response and already_assigned in response.get('text'):
                 exception = ib_ex.InfobloxMemberAlreadyAssigned
             else:
                 exception = ib_ex.InfobloxCannotCreateObject

--- a/infoblox_client/tests/unit/test_connector.py
+++ b/infoblox_client/tests/unit/test_connector.py
@@ -81,6 +81,22 @@ class TestInfobloxConnector(base.TestCase):
                 verify=False
             )
 
+    def test_create_object_raises_member_assigned(self):
+        nios_error = (
+            '{ "Error": "AdmConDataError: None (IBDataConflictError:'
+            'IB.Data.Conflict:Member 10.39.12.91 is assigned to another '
+            'network view \'test2\')",'
+            '"code": "Client.Ibap.Data.Conflict",'
+            '"text": "Member 10.39.12.91 is assigned to another '
+            'network view \'test2\'"}')
+        with patch.object(requests.Session, 'post',
+                          return_value=mock.Mock()) as patched_create:
+            patched_create.return_value.status_code = 400
+            patched_create.return_value.content = nios_error
+            self.assertRaises(exceptions.InfobloxMemberAlreadyAssigned,
+                              self.connector.create_object,
+                              'network', {'network': '192.178.1.0/24'})
+
     def test_get_object(self):
         objtype = 'network'
         payload = {'ip': '0.0.0.0'}


### PR DESCRIPTION
Connector crashes when WAPI returns error message.
Response is a dict, so 'text' field was incorrectly accessed
and caused crash.
Corrected accessing 'text' field in response.
Added UT to validate that correct exception is raised.

Closes: #47