### PR TITLE
Rework delete_all_associated_objects logic

### DIFF
--- a/infoblox_client/tests/unit/test_object_manager.py
+++ b/infoblox_client/tests/unit/test_object_manager.py
@@ -660,41 +660,38 @@ class ObjectManagerTestCase(base.TestCase):
         connector.create_object.assert_called_once_with('zone_auth', matcher,
                                                         mock.ANY)
 
-    def test_delete_all_associated_objects(self):
-        a_rec_ref = ('record:a/ZG5zLmJpbmRfYSQuNC5jb20ubXlfem9uZSxuYW'
-                     '1lLDE5Mi4xNjguMS41:name.my_zone.com/my_dns_view')
-        reply_map = {
-            'ipv4address': [{
-                '_ref': ('ipv4address/Li5pcHY0X2FkZHJlc3MkMTky'
-                         'LjE2OC4xLjEwLzE:192.168.1.10/my_view'),
-                'objects': [a_rec_ref]
-            }],
-            a_rec_ref: {'_ref': a_rec_ref,
-                        'view': 'my_dns_view',
-                        'name': 'name.my_zone.com'},
-        }
-
+    def _mock_for_get_connector(self, reply_map):
         def get_object(ref, *args, **kwargs):
             if ref in reply_map:
                 return reply_map[ref]
 
+        return get_object
+
+    def test_delete_objects_associated_with_a_record(self):
+        name = 'name.my_zone.com'
+        view = 'my_dns_view'
+        delete_list = ['record:cname', 'record:txt']
+        reply_map = {
+            'record:cname': [{'_ref': 'record:cname/some-ref'},
+                             {'_ref': 'record:cname/some-ref2'}],
+            'record:txt': [{'_ref': 'record:txt/txt-ref'}]
+        }
+
         connector = mock.Mock()
+        get_object = self._mock_for_get_connector(reply_map)
         connector.get_object.side_effect = get_object
         ibom = om.InfobloxObjectManager(connector)
-        delete_list = ['record:a']
-        ibom.delete_all_associated_objects('some_view', '192.168.1.10',
-                                           delete_list)
+        ibom.delete_objects_associated_with_a_record(name, view, delete_list)
 
-        payload = {'network_view': 'some_view', 'ip_address': '192.168.1.10'}
-        calls = [mock.call('ipv4address', payload, extattrs=mock.ANY,
-                           force_proxy=mock.ANY, return_fields=mock.ANY),
-                 mock.call(a_rec_ref),
-                 mock.call('record:cname', {'view': 'my_dns_view',
+        calls = [mock.call('record:cname', {'view': 'my_dns_view',
                                             'canonical': 'name.my_zone.com'}),
                  mock.call('record:txt', {'name': 'name.my_zone.com',
                                           'view': 'my_dns_view'})]
-        connector.get_object.assert_has_calls(calls)
-        connector.delete_object.assert_called_once_with(a_rec_ref)
+        connector.get_object.assert_has_calls(calls, any_order=True)
+        delete_calls = [mock.call('record:cname/some-ref'),
+                        mock.call('record:cname/some-ref2'),
+                        mock.call('record:txt/txt-ref')]
+        connector.delete_object.assert_has_calls(delete_calls, any_order=True)
 
     def test_delete_object_by_ref(self):
         """Verify that exception would not be raised for delete by reference.


### PR DESCRIPTION
NIOS Cloud Platform Member does not allow to search records using
'ipv4address'/'ipv6address' NIOS type.

To be able to delete all associated records another approch is selected.
Now each supported for delete object type is checked separately:
- 'record:a'
- 'record:aaaa'
- 'record:ptr'
- 'record:txt'
- 'record:cname'
To remove first three types unbind_name_from_record_a was reused.
'record:txt' and 'record:cname' do not have ip field in it,
so can not be searched directly. Added
delete_objects_associated_with_a_record to delete related records.

delete_all_associated_objects is now deprecated and
unbind_name_from_record_a should be used instead.

Closes: #46