### PR TITLE
Return None instead of exception if search failed 

### DIFF
--- a/infoblox_client/connector.py
+++ b/infoblox_client/connector.py
@@ -251,12 +251,8 @@ class Connector(object):
         self._validate_authorized(r)
 
         if r.status_code != requests.codes.ok:
-            raise ib_ex.InfobloxSearchError(
-                response=jsonutils.loads(r.content),
-                obj_type=obj_type,
-                content=r.content,
-                code=r.status_code)
-
+            LOG.debug("Error occured on object search: %s", r.content)
+            return None
         return self._parse_reply(r)
 
     @reraise_neutron_exception

--- a/infoblox_client/object_manager.py
+++ b/infoblox_client/object_manager.py
@@ -106,12 +106,9 @@ class InfobloxObjectManager(object):
             range.delete()
 
     def has_networks(self, network_view_name):
-        try:
-            networks = obj.Network.search_all(self.connector,
-                                              network_view=network_view_name)
-            return bool(networks)
-        except ib_ex.InfobloxSearchError:
-            return False
+        networks = obj.Network.search_all(self.connector,
+                                          network_view=network_view_name)
+        return bool(networks)
 
     def network_exists(self, network_view, cidr):
         """Deprecated, use get_network() instead."""
@@ -245,11 +242,8 @@ class InfobloxObjectManager(object):
         return host_record.update()
 
     def has_dns_zones(self, dns_view):
-        try:
-            zones = obj.DNSZone.search_all(self.connector, view=dns_view)
-            return bool(zones)
-        except ib_ex.InfobloxSearchError:
-            return False
+        zones = obj.DNSZone.search_all(self.connector, view=dns_view)
+        return bool(zones)
 
     def create_dns_zone(self, dns_view, dns_zone,
                         grid_primary=None, grid_secondaries=None,
@@ -359,11 +353,7 @@ class InfobloxObjectManager(object):
         return member
 
     def get_all_ea_definitions(self):
-        try:
-            ea_defs = obj.EADefinition.search_all(self.connector)
-            return ea_defs
-        except ib_ex.InfobloxSearchError:
-            return None
+        return obj.EADefinition.search_all(self.connector)
 
     def create_ea_definition(self, ea_def):
         try:

--- a/infoblox_client/tests/unit/test_connector.py
+++ b/infoblox_client/tests/unit/test_connector.py
@@ -213,6 +213,16 @@ class TestInfobloxConnector(base.TestCase):
                            mock.call('network', {}, None, force_proxy=True)]
         self.connector._construct_url.assert_has_calls(construct_calls)
 
+    def test__get_object_search_error_return_none(self):
+        response = mock.Mock()
+        response.status_code = '404'
+        response.content = 'Object not found'
+        self.connector.session = mock.Mock()
+        self.connector.session.get.return_value = response
+
+        url = 'http://some-url/'
+        self.assertEqual(None, self.connector._get_object('network', url))
+
 
 class TestInfobloxConnectorStaticMethods(base.TestCase):
     def test_neutron_exception_is_raised_on_any_request_error(self):


### PR DESCRIPTION
Raising ib_ex.InfobloxSearchError exception was replaced with returning
None if NIOS replied with non-ok code.
Updated object_manager methods accordingly to remove exception handling,
since this exception is no longer raised.

Added UT to validate that None is returned if non-ok code is returned.

Closes: #57