### PR TITLE
Add ip_version as a public property

### DIFF
--- a/infoblox_client/objects.py
+++ b/infoblox_client/objects.py
@@ -386,6 +386,10 @@ class InfobloxObject(BaseObject):
     def return_fields(self):
         return self._return_fields
 
+    @property
+    def ip_version(self):
+        return self._ip_version
+
     @classmethod
     def get_class_from_args(cls, kwargs):
         # skip processing if cls already versioned class

--- a/infoblox_client/tests/unit/test_objects.py
+++ b/infoblox_client/tests/unit/test_objects.py
@@ -347,3 +347,10 @@ class TestObjects(base.TestCase):
             a_record[0]['_ref'],
             {'name': 'some-new_name'},
             mock.ANY)
+
+    def test_ip_version(self):
+        conn = mock.Mock()
+        net_v4 = objects.Network(conn, network='192.168.1.0/24')
+        self.assertEqual(4, net_v4.ip_version)
+        net_v6 = objects.Network(conn, network='fffe::/64')
+        self.assertEqual(6, net_v6.ip_version)


### PR DESCRIPTION
Old way of getting ip version for ib_objects is accessing privite
variable _ip_version.
Adding ip_version as part of public interface.
Includes UT to validate field is returned correctly.

Closes: #56