### PR TITLE
Update existent EA for network instead of replace

### DIFF
--- a/infoblox_client/object_manager.py
+++ b/infoblox_client/object_manager.py
@@ -139,7 +139,14 @@ class InfobloxObjectManager(object):
 
     def update_network_options(self, ib_network, extattrs=None):
         if extattrs:
-            ib_network.extattrs = extattrs
+            if ib_network.extattrs:
+                # Merge EA values as dicts
+                ea_dict = ib_network.extattrs.ea_dict
+                ea_dict.update(extattrs.ea_dict)
+                merged_ea = obj.EA(ea_dict)
+                ib_network.extattrs = merged_ea
+            else:
+                ib_network.extattrs = extattrs
         return ib_network.update()
 
     def get_host_record(self, dns_view, ip):

--- a/infoblox_client/objects.py
+++ b/infoblox_client/objects.py
@@ -132,6 +132,11 @@ class EA(object):
                    for name in self._ea_dict)
         return "EAs:{0}".format(','.join(eas))
 
+    @property
+    def ea_dict(self):
+        """Returns dict with EAs in {ea_name: ea_value} format."""
+        return self._ea_dict.copy()
+
     @staticmethod
     def _value_to_bool(value):
         """Converts value returned by NIOS into boolean if possible."""

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -317,6 +317,16 @@ class TestObjects(unittest.TestCase):
         self.assertEqual(id, ea.get(ea_name))
         self.assertEqual(generated_eas, ea.to_dict())
 
+    def test_ea_returns_ea_dict(self):
+        ea_dict = {'Subnet ID': 'some-id'}
+        ea = objects.EA(ea_dict)
+        ea_dict_from_EA_object = ea.ea_dict
+        self.assertEqual(ea_dict, ea_dict_from_EA_object)
+        # Make sure a copy of dict is returned,
+        # and updating returned value do not affect EA object
+        ea_dict_from_EA_object['Subnet ID'] = 'another-id'
+        self.assertEqual('some-id', ea.get('Subnet ID'))
+
     def test_update_from_dict(self):
         net = objects.Network(mock.Mock(), network='192.168.1.0/24')
         self.assertEqual(None, net._ref)


### PR DESCRIPTION
EAs generated on network update replaced all existent EAs for network,
even user defined.
Updated workflow to merge existent network EAs with newly generated EAs.
Newly generated EAs have higher priority over existen EAs.

Added ea_dict property to EA object interface to be able to retrieve internal
representation of eas in {ea_name: ea_value} format.

Closes: #63