### PR TITLE
Allow domain-name-servers for ipv6

### DIFF
--- a/infoblox_client/object_manager.py
+++ b/infoblox_client/object_manager.py
@@ -62,7 +62,7 @@ class InfobloxObjectManager(object):
         ipv4 = ib_utils.determine_ip_version(cidr) == 4
 
         options = []
-        if ipv4 and nameservers:
+        if nameservers:
             options.append(obj.DhcpOption(name='domain-name-servers',
                                           value=",".join(nameservers)))
         if ipv4 and gateway_ip:


### PR DESCRIPTION
Previously domain-name-servers option generation was turned off for ipv6
with other dhcp options ('routers' and 'dhcp-server-identifier').
Using this options caused failures for ipv6 on network creation.

But deeper investigation shows that 'domain-name-servers' is a valid
option for ipv6, so enabling it.

Closes: #64