### PR TITLE
Convert strings into booleans for ssl_verify

### DIFF
--- a/infoblox_client/connector.py
+++ b/infoblox_client/connector.py
@@ -110,7 +110,8 @@ class Connector(object):
         self.session.mount('http://', adapter)
         self.session.mount('https://', adapter)
         self.session.auth = (self.username, self.password)
-        self.session.verify = self.ssl_verify
+        self.session.verify = utils.try_value_to_bool(self.ssl_verify,
+                                                      strict_mode=False)
 
         if self.silent_ssl_warnings:
             requests.packages.urllib3.disable_warnings()

--- a/infoblox_client/objects.py
+++ b/infoblox_client/objects.py
@@ -151,8 +151,9 @@ class EA(object):
         """Converts extensible attributes from the NIOS reply."""
         if not eas_from_nios:
             return
-        return cls({name: cls._value_to_bool(eas_from_nios[name]['value'])
-                    for name in eas_from_nios})
+        return cls(
+            {name: ib_utils.try_value_to_bool(eas_from_nios[name]['value'])
+             for name in eas_from_nios})
 
     def to_dict(self):
         """Converts extensible attributes into the format suitable for NIOS."""

--- a/infoblox_client/utils.py
+++ b/infoblox_client/utils.py
@@ -81,3 +81,35 @@ def safe_json_load(data):
         return jsonutils.loads(data)
     except ValueError:
         LOG.warn("Could not decode reply into json: %s", data)
+
+
+def try_value_to_bool(value, strict_mode=True):
+    """Tries to convert value into boolean.
+
+    strict_mode is True:
+    - Only string representation of str(True) and str(False)
+      are converted into booleans;
+    - Otherwise unchanged incoming value is returned;
+
+    strict_mode is False:
+    - Anything that looks like True or False is converted into booleans.
+    Values accepted as True:
+    - 'true', 'on', 'yes' (case independent)
+    Values accepted as False:
+    - 'false', 'off', 'no' (case independent)
+    - all other values are returned unchanged
+    """
+    if strict_mode:
+        true_list = ('True',)
+        false_list = ('False',)
+        val = value
+    else:
+        true_list = ('true', 'on', 'yes')
+        false_list = ('false', 'off', 'no')
+        val = str(value).lower()
+
+    if val in true_list:
+        return True
+    elif val in false_list:
+        return False
+    return value

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -43,3 +43,35 @@ class TestUtils(unittest.TestCase):
         data = '{"array":[1,2,3]}'
         expected_data = {'array': [1, 2, 3]}
         self.assertEqual(expected_data, utils.safe_json_load(data))
+
+    def test_try_value_to_bool(self):
+        test_data = ((True, True),
+                     (False, False),
+                     (str(True), True),
+                     (str(False), False),
+                     ('True', True),
+                     ('False', False),
+                     ('TRUE', 'TRUE'),
+                     ('FALSE', 'FALSE'),
+                     ('/path/to/file', '/path/to/file'))
+        for value, result in test_data:
+            self.assertEqual(result, utils.try_value_to_bool(value))
+
+    def test_try_value_to_bool_not_strict(self):
+        true_values = (True, 'True', 'true', 'TRUE', 'tRUE',
+                       'On', 'ON', 'on', 'oN',
+                       'Yes', 'YES', 'yes')
+        for v in true_values:
+            self.assertEqual(True,
+                             utils.try_value_to_bool(v, strict_mode=False))
+
+        false_values = (False, 'False', 'false', 'FALSE', 'fALSE',
+                        'Off', 'OFF', 'off',
+                        'No', 'NO', 'no')
+        for v in false_values:
+            self.assertEqual(False,
+                             utils.try_value_to_bool(v, strict_mode=False))
+
+        unchanged_values = ('/path/to/file', 'YES!', '/tmp/certificate')
+        for v in unchanged_values:
+            self.assertEqual(v, utils.try_value_to_bool(v, strict_mode=False))


### PR DESCRIPTION
ssl_verify for Connector was passed to requests.Session.verify without
changes. ssl_verify can be boolean or string.
If it is a string it was excected to contain path to certificate.

To simplify using ssl_verify option now it can be passed in as string,
that containg 'True' or 'False'. In this case string would be converted
to boolean and passed into requests.
All other values are passed as is, i.e. booleans are passed unchanged,
as well as any string that is not equals to 'True' or 'False'.

Converting value to bool was moved from objects into utils,
because now used from connector as well.

Closes: #65