### PR TITLE
create_required_ea_definitions return created list

### DIFF
--- a/infoblox_client/object_manager.py
+++ b/infoblox_client/object_manager.py
@@ -379,6 +379,7 @@ class InfobloxObjectManager(object):
 
         for ea_def in missing_ea_defs:
             self.create_ea_definition(ea_def)
+        return missing_ea_defs
 
     def restart_all_services(self, member):
         if not member._ref:

--- a/infoblox_client/utils.py
+++ b/infoblox_client/utils.py
@@ -13,11 +13,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import datetime
-import decimal
 import netaddr
 import random
-import re
 import six
 
 from oslo_log import log as logging

--- a/tests/test_object_manager.py
+++ b/tests/test_object_manager.py
@@ -766,8 +766,9 @@ class ObjectManagerTestCase(unittest.TestCase):
         connector.get_object.return_value = existing_ea_defs
 
         ibom = om.InfobloxObjectManager(connector)
-        ibom.create_required_ea_definitions(required_ea_defs)
+        created = ibom.create_required_ea_definitions(required_ea_defs)
 
+        self.assertEqual(created, additional_ea_defs)
         connector.create_object.assert_called_once_with(
             'extensibleattributedef',
             additional_ea_defs[0],


### PR DESCRIPTION
create_required_ea_definitions return list of EA Definitions
that were missing and were therefore created.
This list is used for reporting purpose.

Also removed unused imports in utils.py