### PR TITLE
create_required_ea_definitions return created list

### DIFF
--- a/infoblox_client/object_manager.py
+++ b/infoblox_client/object_manager.py
@@ -373,12 +373,16 @@ class InfobloxObjectManager(object):
 
     def create_required_ea_definitions(self, required_ea_defs):
         existing_ea_defs = self.get_all_ea_definitions()
-        missing_ea_defs = filter(lambda x: not next(
-            (y for y in existing_ea_defs if x['name'] == y.name), None),
-            required_ea_defs)
+        missing_ea_defs = []
+        for req_def in required_ea_defs:
+            if not [ea_def for ea_def in existing_ea_defs
+                    if ea_def.name == req_def['name']]:
+                missing_ea_defs.append(req_def)
 
         for ea_def in missing_ea_defs:
             self.create_ea_definition(ea_def)
+
+        return missing_ea_defs
 
     def restart_all_services(self, member):
         if not member._ref:

--- a/tests/test_object_manager.py
+++ b/tests/test_object_manager.py
@@ -766,8 +766,9 @@ class ObjectManagerTestCase(unittest.TestCase):
         connector.get_object.return_value = existing_ea_defs
 
         ibom = om.InfobloxObjectManager(connector)
-        ibom.create_required_ea_definitions(required_ea_defs)
+        created = ibom.create_required_ea_definitions(required_ea_defs)
 
+        self.assertEqual(created[0], additional_ea_defs[0])
         connector.create_object.assert_called_once_with(
             'extensibleattributedef',
             additional_ea_defs[0],


### PR DESCRIPTION
create_required_ea_definitions return list of EA Definitions
that were missing and were therefore created.
This list is used for reporting purpose.