### PR TITLE
Add 'start_addr', 'end_addr' to ip detection list

### DIFF
--- a/infoblox_client/objects.py
+++ b/infoblox_client/objects.py
@@ -402,7 +402,8 @@ class InfobloxObject(BaseObject):
         if cls._ip_version:
             return cls
 
-        for field in ['ip', 'cidr', 'start_ip', 'ip_address', 'network']:
+        for field in ['ip', 'cidr', 'start_ip', 'ip_address', 'network',
+                      'start_addr', 'end_addr']:
             if field in kwargs:
                 if ib_utils.determine_ip_version(kwargs[field]) == 6:
                     return cls.get_v6_class()


### PR DESCRIPTION
'start_addr', 'end_addr' fiels from IPRange were not taken into account
on detecting IP version of object.
Added them to the list of fields that can contain ip versioned object.

Closes: #77