### PR TITLE
Add support for list and tuple values to EA object

### DIFF
--- a/infoblox_client/objects.py
+++ b/infoblox_client/objects.py
@@ -151,15 +151,28 @@ class EA(object):
         """Converts extensible attributes from the NIOS reply."""
         if not eas_from_nios:
             return
-        return cls(
-            {name: ib_utils.try_value_to_bool(eas_from_nios[name]['value'])
-             for name in eas_from_nios})
+        return cls({name: cls._process_value(ib_utils.try_value_to_bool,
+                                             eas_from_nios[name]['value'])
+                    for name in eas_from_nios})
 
     def to_dict(self):
         """Converts extensible attributes into the format suitable for NIOS."""
-        return {name: {'value': str(value)}
+        return {name: {'value': self._process_value(str, value)}
                 for name, value in self._ea_dict.items()
                 if not (value is None or value == "" or value == [])}
+
+    @staticmethod
+    def _process_value(func, value):
+        """Applies processing method for value or each element in it.
+
+        :param func: method to be called with value
+        :param value: value to process
+        :return: if 'value' is list/tupe, returns iterable with func results,
+                 else func result is returned
+        """
+        if isinstance(value, (list, tuple)):
+            return [func(item) for item in value]
+        return func(value)
 
     def get(self, name, default=None):
         """Return value of requested EA."""

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -256,6 +256,14 @@ class TestObjects(unittest.TestCase):
         self.assertIsInstance(ip, objects.IPv4Address)
         self.assertEqual(ip_mock[0]['objects'], ip.objects)
 
+    def test__process_value(self):
+        data = (([1, 2, 3], ['1', '2', '3']),
+                ((1, 2), ['1', '2']),
+                (1, '1'),
+                ('string', 'string'))
+        for input, output in data:
+            self.assertEqual(output, objects.EA._process_value(str, input))
+
     def test_ea_parse_generate(self):
         eas = {'Subnet ID': {'value': 'some-id'},
                'Tenant Name': {'value': 'tenant-name'},
@@ -283,6 +291,15 @@ class TestObjects(unittest.TestCase):
               'None String EA': 'None',
               'Empty List EA': [],
               'Zero String EA': '0'}
+        processed_ea = {'Subnet ID': 'some-id',
+                        'Tenant Name':  'tenant-name',
+                        'Cloud API Owned': 'True',
+                        'DNS Record Types': ['record_a', 'record_ptr'],
+                        'False String EA': 'False',
+                        'False EA': 'False',
+                        'Zero EA': '0',
+                        'None String EA': 'None',
+                        'Zero String EA': '0'}
         ea_exist = ['Subnet ID',
                     'Tenant Name',
                     'Cloud API Owned',
@@ -301,8 +318,8 @@ class TestObjects(unittest.TestCase):
             self.assertEqual(True, key in ea_dict)
         for key in ea_purged:
             self.assertEqual(False, key in ea_dict)
-        for key in ea_exist:
-            self.assertEqual(str(ea.get(key)), ea_dict.get(key).get('value'))
+        for key in processed_ea:
+            self.assertEqual(processed_ea[key], ea_dict.get(key).get('value'))
 
     def test_ea_returns_none(self):
         for ea in (None, '', 0):


### PR DESCRIPTION
Previously processing rule was applied to value directly,
so list values were converted to stings as a result.

Currently if value of EA is list of tuple, then processing rule would be
applied on per element basis.

Closes: #84