### PR TITLE
Add return_fields to NetworkView

### DIFF
--- a/infoblox_client/objects.py
+++ b/infoblox_client/objects.py
@@ -835,6 +835,7 @@ class PtrRecordV6(PtrRecord):
 class NetworkView(InfobloxObject):
     _infoblox_type = 'networkview'
     _fields = ['name', 'extattrs']
+    _return_fields = ['name', 'extattrs', 'is_default']
     _search_fields = ['name']
     _shadow_fields = ['_ref', 'is_default']
     _ip_version = 'any'


### PR DESCRIPTION
Extensible attributes are not returned by default for NetworkView
object. To be able to merge old EAs with new EAs, 'extattrs' field
should present in return fields.
Updated NetworkView model to explicetely request 'extattrs' via return
fields.

Closes: #89