### PR TITLE
Add 'configure_for_dns' field for HostRecord

### DIFF
--- a/infoblox_client/object_manager.py
+++ b/infoblox_client/object_manager.py
@@ -162,19 +162,21 @@ class InfobloxObjectManager(object):
 
     def create_host_record_for_given_ip(self, dns_view, zone_auth,
                                         hostname, mac, ip, extattrs,
-                                        use_dhcp):
+                                        use_dhcp, use_dns=True):
         name = '.'.join([hostname, zone_auth])
         ip_obj = obj.IP.create(ip=ip, mac=mac, configure_for_dhcp=use_dhcp)
         return obj.HostRecord.create(self.connector,
                                      view=dns_view,
                                      name=name,
                                      ip=ip_obj,
+                                     configure_for_dns=use_dns,
                                      extattrs=extattrs,
                                      check_if_exists=False)
 
     def create_host_record_from_range(self, dns_view, network_view_name,
                                       zone_auth, hostname, mac, first_ip,
-                                      last_ip, extattrs, use_dhcp):
+                                      last_ip, extattrs, use_dhcp,
+                                      use_dns=True):
         name = '.'.join([hostname, zone_auth])
         ip_alloc = obj.IPAllocation.next_available_ip_from_range(
             network_view_name, first_ip, last_ip)
@@ -184,6 +186,7 @@ class InfobloxObjectManager(object):
                                      view=dns_view,
                                      name=name,
                                      ip=ip_obj,
+                                     configure_for_dns=use_dns,
                                      extattrs=extattrs,
                                      check_if_exists=False)
 

--- a/infoblox_client/objects.py
+++ b/infoblox_client/objects.py
@@ -531,7 +531,8 @@ class HostRecord(InfobloxObject):
 
 class HostRecordV4(HostRecord):
     """HostRecord for IPv4"""
-    _fields = ['ipv4addrs', 'view', 'extattrs', 'name', 'zone']
+    _fields = ['ipv4addrs', 'view', 'extattrs', 'name', 'zone',
+               'configure_for_dns']
     _search_fields = ['view', 'ipv4addr', 'name', 'zone']
     _updateable_search_fields = ['name']
     _shadow_fields = ['_ref', 'ipv4addr']
@@ -563,7 +564,8 @@ class HostRecordV4(HostRecord):
 
 class HostRecordV6(HostRecord):
     """HostRecord for IPv6"""
-    _fields = ['ipv6addrs', 'view', 'extattrs',  'name', 'zone']
+    _fields = ['ipv6addrs', 'view', 'extattrs',  'name', 'zone',
+               'configure_for_dns']
     _search_fields = ['ipv6addr', 'view', 'name', 'zone']
     _updateable_search_fields = ['name']
     _shadow_fields = ['_ref', 'ipv6addr']

--- a/tests/test_object_manager.py
+++ b/tests/test_object_manager.py
@@ -91,6 +91,7 @@ class ObjectManagerTestCase(unittest.TestCase):
         ip = '192.168.0.1'
         mac = 'aa:bb:cc:dd:ee:ff'
         use_dhcp = True
+        use_dns = True
 
         host_record = {'_ref': 'host_record_ref'}
         connector = mock.Mock()
@@ -100,14 +101,15 @@ class ObjectManagerTestCase(unittest.TestCase):
 
         ibom.create_host_record_for_given_ip(dns_view_name, zone_auth,
                                              hostname, mac, ip, self.EXT_ATTRS,
-                                             use_dhcp)
+                                             use_dhcp, use_dns)
 
         exp_payload = {
             'name': 'test_hostname.test.dns.zone.com',
             'view': dns_view_name,
+            'configure_for_dns': use_dns,
             'extattrs': self.EXT_ATTRS,
             'ipv4addrs': [
-                {'mac': mac, 'configure_for_dhcp': True, 'ipv4addr': ip}
+                {'mac': mac, 'configure_for_dhcp': use_dhcp, 'ipv4addr': ip}
             ]
         }
 
@@ -123,6 +125,8 @@ class ObjectManagerTestCase(unittest.TestCase):
         net_view_name = 'test_net_view_name'
         first_ip = '192.168.0.1'
         last_ip = '192.168.0.254'
+        use_dhcp = True
+        use_dns = False
 
         host_record = {'_ref': 'host_record_ref'}
         connector = mock.Mock()
@@ -132,16 +136,19 @@ class ObjectManagerTestCase(unittest.TestCase):
 
         ibom.create_host_record_from_range(
             dns_view_name, net_view_name, zone_auth, hostname, mac, first_ip,
-            last_ip, self.EXT_ATTRS, True)
+            last_ip, self.EXT_ATTRS, use_dhcp, use_dns)
 
         next_ip = \
             'func:nextavailableip:192.168.0.1-192.168.0.254,test_net_view_name'
         exp_payload = {
             'name': 'test_hostname.test.dns.zone.com',
+            'configure_for_dns': use_dns,
             'view': dns_view_name,
             'extattrs': self.EXT_ATTRS,
             'ipv4addrs': [
-                {'mac': mac, 'configure_for_dhcp': True, 'ipv4addr': next_ip}
+                {'mac': mac,
+                 'configure_for_dhcp': use_dhcp,
+                 'ipv4addr': next_ip}
             ]
         }
         connector.create_object.assert_called_once_with(


### PR DESCRIPTION
'configure_for_dns' can be set to False to create host record without
dns zones.
Added this field to HostRecordV4 and HostRecordV6 objects.
Updated create_host_record_for_given_ip and
create_host_record_from_range to optionally accept 'use_dns' flag,
which is True by default.
Having 'use_dns' as an optional flag does not brake backward
compatibility with older versions.

Closes: #94