### PR TITLE
Add max_results option to connector and objects

### DIFF
--- a/infoblox_client/connector.py
+++ b/infoblox_client/connector.py
@@ -158,7 +158,8 @@ class Connector(object):
             raise ib_ex.InfobloxBadWAPICredential(response='')
 
     @staticmethod
-    def _build_query_params(payload=None, return_fields=None):
+    def _build_query_params(payload=None, return_fields=None,
+                            max_results=None):
         if payload:
             query_params = payload
         else:
@@ -166,6 +167,8 @@ class Connector(object):
 
         if return_fields:
             query_params['_return_fields'] = ','.join(return_fields)
+        if max_results:
+            query_params['_max_results'] = max_results
         return query_params
 
     def _get_request_options(self, data=None):
@@ -196,7 +199,7 @@ class Connector(object):
 
     @reraise_neutron_exception
     def get_object(self, obj_type, payload=None, return_fields=None,
-                   extattrs=None, force_proxy=False):
+                   extattrs=None, force_proxy=False, max_results=None):
         """Retrieve a list of Infoblox objects of type 'obj_type'
 
         Some get requests like 'ipv4address' should be always
@@ -214,6 +217,11 @@ class Connector(object):
             extattrs      (list): List of Extensible Attributes
             force_proxy   (bool): Set _proxy_search flag
                                   to process requests on GM
+            max_results   (int): Maximum number of objects to be returned.
+                If set to a negative number the appliance will return an error
+                when the number of returned objects would exceed the setting.
+                The default is -1000. If this is set to a positive number,
+                the results will be truncated when necessary.
         Returns:
             A list of the Infoblox objects requested
         Raises:
@@ -222,7 +230,8 @@ class Connector(object):
         self._validate_obj_type_or_die(obj_type, obj_type_expected=False)
 
         query_params = self._build_query_params(payload=payload,
-                                                return_fields=return_fields)
+                                                return_fields=return_fields,
+                                                max_results=max_results)
 
         # Clear proxy flag if wapi version is too old (non-cloud)
         proxy_flag = self.cloud_api_enabled and force_proxy

--- a/infoblox_client/objects.py
+++ b/infoblox_client/objects.py
@@ -318,7 +318,8 @@ class InfobloxObject(BaseObject):
 
     @classmethod
     def _search(cls, connector, return_fields=None,
-                search_extattrs=None, force_proxy=False, **kwargs):
+                search_extattrs=None, force_proxy=False,
+                max_results=None, **kwargs):
         ib_obj_for_search = cls(connector, **kwargs)
         search_dict = ib_obj_for_search.to_dict(search_fields='only')
         if return_fields is None and ib_obj_for_search.return_fields:
@@ -332,7 +333,8 @@ class InfobloxObject(BaseObject):
                                      search_dict,
                                      return_fields=return_fields,
                                      extattrs=extattrs,
-                                     force_proxy=force_proxy)
+                                     force_proxy=force_proxy,
+                                     max_results=max_results)
         return reply, ib_obj_for_search
 
     @classmethod

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -126,6 +126,20 @@ class TestInfobloxConnector(unittest.TestCase):
                 timeout=self.default_opts.http_request_timeout,
             )
 
+    def test_get_objects_with_max_results(self):
+        objtype = 'network'
+        with patch.object(requests.Session, 'get',
+                          return_value=mock.Mock()) as patched_get:
+            patched_get.return_value.status_code = 200
+            patched_get.return_value.content = '{}'
+            self.connector.get_object(objtype, {}, max_results=20)
+            patched_get.assert_called_once_with(
+                'https://infoblox.example.org/wapi/'
+                'v1.1/network?_max_results=20',
+                headers=self.connector.DEFAULT_HEADER,
+                timeout=self.default_opts.http_request_timeout,
+            )
+
     def test_update_object(self):
         ref = 'network'
         payload = {'ip': '0.0.0.0'}

--- a/tests/test_object_manager.py
+++ b/tests/test_object_manager.py
@@ -168,7 +168,7 @@ class ObjectManagerTestCase(unittest.TestCase):
         matcher = PayloadMatcher({'view': dns_view_name,
                                   PayloadMatcher.ANYKEY: ip_address})
         connector.get_object.assert_called_once_with(
-            'record:host', matcher, extattrs=None,
+            'record:host', matcher, extattrs=None, max_results=None,
             force_proxy=mock.ANY, return_fields=mock.ANY)
         connector.delete_object.assert_called_once_with(mock.ANY)
 
@@ -186,7 +186,7 @@ class ObjectManagerTestCase(unittest.TestCase):
         matcher = PayloadMatcher({'network_view': net_view_name,
                                   'network': cidr})
         connector.get_object.assert_called_once_with(
-            'network', matcher, extattrs=None,
+            'network', matcher, extattrs=None, max_results=None,
             force_proxy=mock.ANY, return_fields=mock.ANY)
 
     def test_object_is_not_created_if_already_exists(self):
@@ -310,7 +310,7 @@ class ObjectManagerTestCase(unittest.TestCase):
         matcher = PayloadMatcher({'start_addr': start_ip,
                                   'network_view': net_view})
         connector.get_object.assert_called_once_with(
-            'range', matcher, extattrs=None,
+            'range', matcher, extattrs=None, max_results=None,
             force_proxy=mock.ANY, return_fields=mock.ANY)
         connector.delete_object.assert_called_once_with(mock.ANY)
 
@@ -328,7 +328,7 @@ class ObjectManagerTestCase(unittest.TestCase):
         matcher = PayloadMatcher({'network_view': net_view,
                                   'network': cidr})
         connector.get_object.assert_called_once_with(
-            'network', matcher, extattrs=None,
+            'network', matcher, extattrs=None, max_results=None,
             force_proxy=mock.ANY, return_fields=mock.ANY)
         connector.delete_object.assert_called_once_with(mock.ANY)
 
@@ -344,7 +344,7 @@ class ObjectManagerTestCase(unittest.TestCase):
 
         matcher = PayloadMatcher({'name': net_view})
         connector.get_object.assert_called_once_with(
-            'networkview', matcher, extattrs=None,
+            'networkview', matcher, extattrs=None, max_results=None,
             force_proxy=mock.ANY, return_fields=mock.ANY)
         connector.delete_object.assert_called_once_with(mock.ANY)
 
@@ -362,7 +362,8 @@ class ObjectManagerTestCase(unittest.TestCase):
         connector.get_object.assert_called_once_with(
             'record:host',
             {'view': dns_view_name, 'name': fqdn, 'ipv4addr': ip},
-            extattrs=None, force_proxy=mock.ANY, return_fields=mock.ANY)
+            extattrs=None, force_proxy=mock.ANY, return_fields=mock.ANY,
+            max_results=None)
 
     def test_bind_names_updates_host_record(self):
         dns_view_name = 'dns-view-name'
@@ -380,7 +381,7 @@ class ObjectManagerTestCase(unittest.TestCase):
         matcher = PayloadMatcher({'view': dns_view_name,
                                   PayloadMatcher.ANYKEY: ip})
         connector.get_object.assert_called_once_with(
-            'record:host', matcher, extattrs=None,
+            'record:host', matcher, extattrs=None, max_results=None,
             force_proxy=mock.ANY, return_fields=mock.ANY)
 
         matcher = PayloadMatcher({'name': fqdn})
@@ -423,7 +424,7 @@ class ObjectManagerTestCase(unittest.TestCase):
         bind_list = ['record:a', 'record:aaaa', 'record:ptr']
 
         def get_object(obj_type, payload=None, return_fields=None,
-                       extattrs=None, force_proxy=False):
+                       extattrs=None, force_proxy=False, max_results=None):
             data_dict = payload.copy()
             data_dict['_ref'] = 'some-ref/' + obj_type
             return [data_dict]
@@ -475,7 +476,7 @@ class ObjectManagerTestCase(unittest.TestCase):
 
         matcher = PayloadMatcher({'network_view': net_view_name})
         connector.get_object.assert_called_once_with(
-            'network', matcher, return_fields=mock.ANY,
+            'network', matcher, return_fields=mock.ANY, max_results=None,
             force_proxy=mock.ANY, extattrs=None)
         self.assertEqual(False, result)
 
@@ -565,7 +566,7 @@ class ObjectManagerTestCase(unittest.TestCase):
         payload = {'network_view': network_view,
                    'ipv4addr': ip}
         connector.get_object.assert_called_once_with(
-            'fixedaddress', payload, extattrs=None,
+            'fixedaddress', payload, extattrs=None, max_results=None,
             return_fields=mock.ANY, force_proxy=mock.ANY)
         connector.delete_object.assert_called_once_with(mock.ANY)
 
@@ -582,7 +583,7 @@ class ObjectManagerTestCase(unittest.TestCase):
         payload = {'network_view': network_view,
                    'ipv4addr': ip}
         connector.get_object.assert_called_once_with(
-            'fixedaddress', payload, extattrs=None,
+            'fixedaddress', payload, extattrs=None, max_results=None,
             return_fields=mock.ANY, force_proxy=mock.ANY)
         self.assertFalse(connector.delete_object.called)
 
@@ -746,7 +747,8 @@ class ObjectManagerTestCase(unittest.TestCase):
                                                      {},
                                                      extattrs=None,
                                                      force_proxy=mock.ANY,
-                                                     return_fields=mock.ANY)
+                                                     return_fields=mock.ANY,
+                                                     max_results=None)
 
     def test_create_ea_definition(self):
         connector = mock.Mock()

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -59,7 +59,8 @@ class TestObjects(unittest.TestCase):
         connector.get_object.assert_called_once_with(
             'network',
             {'network_view': 'some-view', 'network': '192.68.1.0/20'},
-            extattrs=None, force_proxy=False, return_fields=mock.ANY)
+            extattrs=None, force_proxy=False, return_fields=mock.ANY,
+            max_results=None)
 
     def test_search_network_v6(self):
         connector = self._mock_connector()
@@ -70,7 +71,8 @@ class TestObjects(unittest.TestCase):
         connector.get_object.assert_called_once_with(
             'ipv6network',
             {'network_view': 'some-view', 'network': 'fffe:2312::/64'},
-            extattrs=None, force_proxy=False, return_fields=mock.ANY)
+            extattrs=None, force_proxy=False, return_fields=mock.ANY,
+            max_results=None)
 
     def test_search_network_v6_using_network_field(self):
         connector = self._mock_connector()
@@ -81,7 +83,8 @@ class TestObjects(unittest.TestCase):
         connector.get_object.assert_called_once_with(
             'ipv6network',
             {'network_view': 'some-view', 'network': 'fffe:2312::/64'},
-            extattrs=None, force_proxy=False, return_fields=mock.ANY)
+            extattrs=None, force_proxy=False, return_fields=mock.ANY,
+            max_results=None)
 
     def test_search_network_with_results(self):
         found = {"_ref": "network/ZG5zLm5ldHdvcmskMTAuMzkuMTEuMC8yNC8w"
@@ -96,7 +99,8 @@ class TestObjects(unittest.TestCase):
         connector.get_object.assert_called_once_with(
             'network',
             {'network_view': 'some-view', 'network': '192.68.1.0/20'},
-            extattrs=None, force_proxy=False, return_fields=mock.ANY)
+            extattrs=None, force_proxy=False, return_fields=mock.ANY,
+            max_results=None)
         self.assertEqual('192.68.1.0/20', network.network)
         self.assertEqual('some-view', network.network_view)
         # verify aliased fields works too
@@ -169,7 +173,8 @@ class TestObjects(unittest.TestCase):
         connector.get_object.assert_called_once_with(
             'record:host',
             {'view': 'some-dns-view', 'ipv4addr': '192.168.15.20'},
-            extattrs=None, force_proxy=False, return_fields=mock.ANY)
+            extattrs=None, force_proxy=False, return_fields=mock.ANY,
+            max_results=None)
 
         # Validate extattrs in host_record are converted to EA object
         self.assertIsInstance(host_record.extattrs, objects.EA)
@@ -252,7 +257,7 @@ class TestObjects(unittest.TestCase):
         payload = {'network_view': 'some_view', 'ip_address': '192.168.1.5'}
         connector.get_object.assert_called_once_with(
             'ipv4address', payload, return_fields=mock.ANY,
-            extattrs=None, force_proxy=mock.ANY)
+            extattrs=None, force_proxy=mock.ANY, max_results=None)
         self.assertIsInstance(ip, objects.IPv4Address)
         self.assertEqual(ip_mock[0]['objects'], ip.objects)
 


### PR DESCRIPTION
max_results option is translated into '_max_results' WAPI option:

Maximum number of objects to be returned. If set to a negative
number the appliance will return an error when the number of returned
objects would exceed the setting. The default is -1000. If this is set
to a positive number, the results will be truncated when necessary.

This option is available for get_object method in connector and
for search and search_all methods for objects that are inherited from
InfobloxObject.

Closes: #62