### PR TITLE
Add Tenant object

### DIFF
--- a/infoblox_client/objects.py
+++ b/infoblox_client/objects.py
@@ -944,3 +944,10 @@ class IPAllocation(object):
     def next_available_ip_from_range(cls, net_view_name, first_ip, last_ip):
         return cls(first_ip, 'func:nextavailableip:{first_ip}-{last_ip},'
                              '{net_view_name}'.format(**locals()))
+
+
+class Tenant(InfobloxObject):
+    _infoblox_type = 'grid:cloudapi:tenant'
+    _fields = ['id', 'name', 'comment']
+    _search_fields = ['id']
+    _shadow_fields = ['_ref']

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -381,3 +381,19 @@ class TestObjects(unittest.TestCase):
         self.assertEqual(4, net_v4.ip_version)
         net_v6 = objects.Network(conn, network='fffe::/64')
         self.assertEqual(6, net_v6.ip_version)
+
+    def test_get_tenant(self):
+        id = 'tenant_id'
+        fake_tenant = {
+            '_ref': 'grid:cloudapi:tenant/ZG5zLm5ldHdvcmskMTAuMzk',
+            'id': id,
+            'name': 'Tenant Name',
+            'comment': 'Some comment'}
+        conn = self._mock_connector(get_object=[fake_tenant])
+        tenant = objects.Tenant.search(conn, id=id)
+        conn.get_object.assert_called_once_with(
+            'grid:cloudapi:tenant', {'id': id},
+            return_fields=mock.ANY, extattrs=None, force_proxy=mock.ANY)
+        self.assertEqual(fake_tenant['id'], tenant.id)
+        self.assertEqual(fake_tenant['name'], tenant.name)
+        self.assertEqual(fake_tenant['comment'], tenant.comment)


### PR DESCRIPTION
Tenant refers to 'grid:cloudapi:tenant' NIOS type and is intended to be
used to update tenant name on NIOS side.

Closes: #96