### PR TITLE
Fix test failure after conflicting changes

### DIFF
--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -398,7 +398,8 @@ class TestObjects(unittest.TestCase):
         tenant = objects.Tenant.search(conn, id=id)
         conn.get_object.assert_called_once_with(
             'grid:cloudapi:tenant', {'id': id},
-            return_fields=mock.ANY, extattrs=None, force_proxy=mock.ANY)
+            return_fields=mock.ANY, extattrs=None, force_proxy=mock.ANY,
+            max_results=None)
         self.assertEqual(fake_tenant['id'], tenant.id)
         self.assertEqual(fake_tenant['name'], tenant.name)
         self.assertEqual(fake_tenant['comment'], tenant.comment)


### PR DESCRIPTION
Adding tenant review had UT in it, and merging add max_results
option broke that UT.
Fixing UT to include max_results in expected parameter for get_object
call.