### PR TITLE
Add max_retries option to connector

### DIFF
--- a/infoblox_client/connector.py
+++ b/infoblox_client/connector.py
@@ -59,6 +59,7 @@ class Connector(object):
                        'http_request_timeout': 10,
                        'http_pool_connections': 10,
                        'http_pool_maxsize': 10,
+                       'max_retries': 3,
                        'wapi_version': '1.4',
                        'max_results': None,
                        'log_api_calls_as_info': False}
@@ -79,7 +80,7 @@ class Connector(object):
     def _parse_options(self, options):
         """Copy needed options to self"""
         attributes = ('host', 'wapi_version', 'username', 'password',
-                      'ssl_verify', 'http_request_timeout',
+                      'ssl_verify', 'http_request_timeout', 'max_retries',
                       'http_pool_connections', 'http_pool_maxsize',
                       'silent_ssl_warnings', 'log_api_calls_as_info',
                       'max_results')
@@ -108,7 +109,8 @@ class Connector(object):
         self.session = requests.Session()
         adapter = requests.adapters.HTTPAdapter(
             pool_connections=self.http_pool_connections,
-            pool_maxsize=self.http_pool_maxsize)
+            pool_maxsize=self.http_pool_maxsize,
+            max_retries=self.max_retries)
         self.session.mount('http://', adapter)
         self.session.mount('https://', adapter)
         self.session.auth = (self.username, self.password)

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -43,6 +43,7 @@ class TestInfobloxConnector(unittest.TestCase):
         opts.http_pool_connections = 10
         opts.http_pool_maxsize = 10
         opts.http_request_timeout = 10
+        opts.max_retries = 3
         opts.max_results = None
         return opts
 
@@ -361,6 +362,7 @@ class TestInfobloxConnectorStaticMethods(unittest.TestCase):
         self.assertEqual(10, conn.http_request_timeout)
         self.assertEqual(10, conn.http_pool_connections)
         self.assertEqual(10, conn.http_pool_maxsize)
+        self.assertEqual(3, conn.max_retries)
         self.assertEqual('1.4', conn.wapi_version)
         self.assertEqual(None, conn.max_results)
 


### PR DESCRIPTION
Passes max_retries option to requests adapters. Default value is 3.

The maximum number of retries each connection should attempt. Note, this
applies only to failed DNS lookups, socket connections and connection
timeouts, never to requests where data has made it to the server. By
default, Requests does not retry failed connections. If you need
granular control over the conditions under which we retry a request,
import urllib3's Retry class and pass that instead.

More info about max_retries can be found in requests documentation [1].

[1]
http://docs.python-requests.org/en/master/api/#requests.adapters.HTTPAdapter

Closes: #104