### PR TITLE
Log failure on get with Error log level

### DIFF
--- a/infoblox_client/connector.py
+++ b/infoblox_client/connector.py
@@ -269,7 +269,7 @@ class Connector(object):
         self._validate_authorized(r)
 
         if r.status_code != requests.codes.ok:
-            LOG.debug("Error occured on object search: %s", r.content)
+            LOG.error("Error occurred on object search: %s", r.content)
             return None
         return self._parse_reply(r)
 


### PR DESCRIPTION
Previously failure on get was logged with debug log level, so error
itself was not seen fby user.
Changed log level for search failures to 'error', so all this error are
logged.

Closes: #107