### PR TITLE
Fetch only object reference for service restart

### DIFF
--- a/infoblox_client/object_manager.py
+++ b/infoblox_client/object_manager.py
@@ -401,7 +401,7 @@ class InfobloxObjectManager(object):
 
     def restart_all_services(self, member):
         if not member._ref:
-            member.fetch()
+            member.fetch(only_ref=True)
         self.connector.call_func('restartservices', member._ref,
                                  {'restart_option': 'RESTART_IF_NEEDED',
                                   'service_option': 'ALL'})


### PR DESCRIPTION
Only member reference is needed for restart, other fields are not used.
So skip fetching unneeded fields.
It also has positive impact on supportability of older wapi versions,
since no return_fields are passed in request, and request will not fail
on older wapi versions like 1.6.