### PR TITLE
Add default fields for Member

### DIFF
--- a/infoblox_client/objects.py
+++ b/infoblox_client/objects.py
@@ -887,7 +887,8 @@ class DNSZone(InfobloxObject):
 class Member(InfobloxObject):
     _infoblox_type = 'member'
     _fields = ['host_name', 'ipv6_setting', 'vip_setting',
-               'extattrs', 'ipv4_address', 'ipv6_address']
+               'extattrs', 'ipv4_address', 'ipv6_address', 'platform',
+               'config_addr_type', 'service_type_configuration']
     _return_fields = ['host_name', 'ipv6_setting', 'node_info',
                       'vip_setting', 'extattrs']
     _search_fields = ['host_name', 'ipv4_address', 'ipv6_address']


### PR DESCRIPTION
Within wapi 2.2+ list of default fields for member object was expanded.
Added support for next fields:
- platform
- config_addr_type
- service_type_configuration

Closes: #118