### PR TITLE
Do not fail on processing unknown fields

### DIFF
--- a/infoblox_client/objects.py
+++ b/infoblox_client/objects.py
@@ -87,11 +87,8 @@ class BaseObject(object):
         for key in kwargs:
             if key in cls._remap:
                 mapped[cls._remap[key]] = kwargs[key]
-            elif key in cls._fields or key in cls._shadow_fields:
-                mapped[key] = kwargs[key]
             else:
-                raise ValueError("Unknown parameter %s for class %s" %
-                                 (key, cls))
+                mapped[key] = kwargs[key]
         return mapped
 
     @classmethod

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -403,3 +403,8 @@ class TestObjects(unittest.TestCase):
         self.assertEqual(fake_tenant['id'], tenant.id)
         self.assertEqual(fake_tenant['name'], tenant.name)
         self.assertEqual(fake_tenant['comment'], tenant.comment)
+
+    def test__remap_fields_support_unknown_fields(self):
+        data = {'host_name': 'cp.com',
+                'unknown_field': 'some_data'}
+        self.assertEqual(data, objects.Member._remap_fields(data))


### PR DESCRIPTION
Previous behavior was to raise an exception on receiving unknown field.
It caused issues when NIOS replied with some unknown yet field.

Currently If unknown field is received it is ignored, and no exception
is raised.