### PR TITLE
Pass only_ref option to update_from_dict

### DIFF
--- a/infoblox_client/objects.py
+++ b/infoblox_client/objects.py
@@ -372,7 +372,7 @@ class InfobloxObject(BaseObject):
                                           search_dict,
                                           return_fields=return_fields)
         if reply:
-            self.update_from_dict(reply[0], only_ref=True)
+            self.update_from_dict(reply[0], only_ref=only_ref)
             return True
         return False
 


### PR DESCRIPTION
Previously if reply is received from NIOS update was forced to
update only dict and skip other fields. In case of only_ref is False
it was inccorect behavior.

Updated code to pass value of only_ref down to update_from_dict.