### PR TITLE
Add network_view support for host records

### DIFF
--- a/infoblox_client/object_manager.py
+++ b/infoblox_client/object_manager.py
@@ -161,16 +161,18 @@ class InfobloxObjectManager(object):
                 ib_network.extattrs = extattrs
         return ib_network.update()
 
-    def get_host_record(self, dns_view, ip):
+    def get_host_record(self, dns_view, ip, network_view=None):
         return obj.HostRecord.search(self.connector,
                                      view=dns_view,
-                                     ip=ip)
+                                     ip=ip,
+                                     network_view=network_view)
 
-    def find_hostname(self, dns_view, hostname, ip):
+    def find_hostname(self, dns_view, hostname, ip, network_view=None):
         return obj.HostRecord.search(self.connector,
                                      name=hostname,
                                      view=dns_view,
-                                     ip=ip)
+                                     ip=ip,
+                                     network_view=network_view)
 
     def create_host_record_for_given_ip(self, dns_view, zone_auth,
                                         hostname, mac, ip, extattrs,
@@ -202,9 +204,10 @@ class InfobloxObjectManager(object):
                                      extattrs=extattrs,
                                      check_if_exists=False)
 
-    def delete_host_record(self, dns_view, ip_address):
+    def delete_host_record(self, dns_view, ip_address, network_view=None):
         host_record = obj.HostRecord.search(self.connector,
-                                            view=dns_view, ip=ip_address)
+                                            view=dns_view, ip=ip_address,
+                                            network_view=network_view)
         if host_record:
             host_record.delete()
 
@@ -319,10 +322,12 @@ class InfobloxObjectManager(object):
             ptr_record.extattrs = extattrs
             ptr_record.update()
 
-    def bind_name_with_host_record(self, dns_view, ip, name, extattrs):
+    def bind_name_with_host_record(self, dns_view, ip, name, extattrs,
+                                   network_view=None):
         host_record = obj.HostRecord.search(self.connector,
                                             view=dns_view,
-                                            ip=ip)
+                                            ip=ip,
+                                            network_view=network_view)
         if host_record:
             host_record.name = name
             host_record.extattrs = extattrs

--- a/infoblox_client/objects.py
+++ b/infoblox_client/objects.py
@@ -531,8 +531,8 @@ class HostRecord(InfobloxObject):
 class HostRecordV4(HostRecord):
     """HostRecord for IPv4"""
     _fields = ['ipv4addrs', 'view', 'extattrs', 'name', 'zone',
-               'configure_for_dns']
-    _search_fields = ['view', 'ipv4addr', 'name', 'zone']
+               'configure_for_dns', 'network_view']
+    _search_fields = ['view', 'ipv4addr', 'name', 'zone', 'network_view']
     _updateable_search_fields = ['name']
     _shadow_fields = ['_ref', 'ipv4addr']
     _return_fields = ['ipv4addrs', 'extattrs']
@@ -564,8 +564,8 @@ class HostRecordV4(HostRecord):
 class HostRecordV6(HostRecord):
     """HostRecord for IPv6"""
     _fields = ['ipv6addrs', 'view', 'extattrs',  'name', 'zone',
-               'configure_for_dns']
-    _search_fields = ['ipv6addr', 'view', 'name', 'zone']
+               'configure_for_dns', 'network_view']
+    _search_fields = ['ipv6addr', 'view', 'name', 'zone', 'network_view']
     _updateable_search_fields = ['name']
     _shadow_fields = ['_ref', 'ipv6addr']
     _return_fields = ['ipv6addrs', 'extattrs']

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -169,10 +169,12 @@ class TestObjects(unittest.TestCase):
 
         host_record = objects.HostRecord.search(connector,
                                                 view='some-dns-view',
-                                                ip='192.168.15.20')
+                                                ip='192.168.15.20',
+                                                network_view='test-netview')
         connector.get_object.assert_called_once_with(
             'record:host',
-            {'view': 'some-dns-view', 'ipv4addr': '192.168.15.20'},
+            {'view': 'some-dns-view', 'ipv4addr': '192.168.15.20',
+             'network_view': 'test-netview'},
             extattrs=None, force_proxy=False, return_fields=mock.ANY,
             max_results=None)
 


### PR DESCRIPTION
Networking-infoblox need to search non-DNS hosts using network view
instead of dns view(non-DNS host root dns views has same name for all
networks views except default)
So add network view support to host and corresponding object_manager
functions.