### PR TITLE
add zones extensible attribute update support

### DIFF
--- a/infoblox_client/object_manager.py
+++ b/infoblox_client/object_manager.py
@@ -291,6 +291,16 @@ class InfobloxObjectManager(object):
         if dns_zone:
             dns_zone.delete()
 
+    def update_dns_zone_attrs(self, dns_view, dns_zone_fqdn, extattrs):
+        if not extattrs:
+            return
+        dns_zone = obj.DNSZone.search(self.connector,
+                                      fqdn=dns_zone_fqdn,
+                                      view=dns_view)
+        if dns_zone:
+            dns_zone.extattrs = extattrs
+            dns_zone.update()
+
     def update_host_record_eas(self, dns_view, ip, extattrs):
         host_record = obj.HostRecord.search(self.connector,
                                             view=dns_view,

--- a/infoblox_client/objects.py
+++ b/infoblox_client/objects.py
@@ -862,12 +862,12 @@ class DNSView(InfobloxObject):
 
 class DNSZone(InfobloxObject):
     _infoblox_type = 'zone_auth'
-    _fields = ['_ref', 'fqdn', 'view', 'extattrs', 'zone_format', 'ns_group',
+    _fields = ['fqdn', 'view', 'extattrs', 'zone_format',
                'prefix', 'grid_primary', 'grid_secondaries']
     _return_fields = ['fqdn', 'view', 'extattrs', 'zone_format', 'ns_group',
                       'prefix', 'grid_primary', 'grid_secondaries']
-    _search_fields = ['fqdn', 'view']
-    _shadow_fields = ['_ref']
+    _search_fields = ['fqdn', 'view', 'zone_format']
+    _shadow_fields = ['_ref', 'ns_group']
     _ip_version = 'any'
 
     @staticmethod

--- a/tests/test_object_manager.py
+++ b/tests/test_object_manager.py
@@ -700,6 +700,39 @@ class ObjectManagerTestCase(unittest.TestCase):
         connector.create_object.assert_called_once_with('zone_auth', matcher,
                                                         mock.ANY)
 
+    def test_update_dns_zone_attrs(self):
+        dns_view_name = 'dns-view-name'
+        fqdn = 'host.global.com'
+        zone_ref = 'zone_ref'
+        old_attrs = {'old_key': {'value': 'old_value'}}
+        new_attrs = {'new_key': {'value': 'new_value'}}
+        zone = {
+            '_ref': zone_ref,
+            'view': dns_view_name,
+            'fqdn': fqdn,
+            'zone_format': 'FORWARD',
+            'ns_group': 'test_group',
+            'extattrs': old_attrs
+            }
+
+        connector = mock.Mock()
+        connector.get_object.return_value = [zone]
+
+        return_fields = [
+            'fqdn', 'view', 'extattrs', 'zone_format', 'ns_group', 'prefix',
+            'grid_primary', 'grid_secondaries']
+        ibom = om.InfobloxObjectManager(connector)
+        ibom.update_dns_zone_attrs(dns_view_name, fqdn, new_attrs)
+        connector.get_object.assert_called_once_with(
+            'zone_auth',
+            {'fqdn': 'host.global.com', 'view': 'dns-view-name'},
+            extattrs=None, force_proxy=False, max_results=None,
+            return_fields=return_fields)
+        connector.update_object.assert_called_once_with(
+            zone_ref,
+            {'extattrs': new_attrs},
+            return_fields)
+
     def _mock_for_get_connector(self, reply_map):
         def get_object(ref, *args, **kwargs):
             if ref in reply_map:


### PR DESCRIPTION
Networknig infoblox need to update DNS zone extensible attributes when
network changes, so add extensible attributes update support for DNSZone
object.