### PR TITLE
Add ptrdname search option to PtrRecord objects

### DIFF
--- a/infoblox_client/objects.py
+++ b/infoblox_client/objects.py
@@ -828,7 +828,7 @@ class PtrRecord(InfobloxObject):
 
 class PtrRecordV4(PtrRecord):
     _fields = ['view', 'ipv4addr', 'ptrdname', 'extattrs']
-    _search_fields = ['view', 'ipv4addr']
+    _search_fields = ['view', 'ipv4addr', 'ptrdname']
     _shadow_fields = ['_ref']
     _remap = {'ip': 'ipv4addr'}
     _ip_version = 4
@@ -836,7 +836,7 @@ class PtrRecordV4(PtrRecord):
 
 class PtrRecordV6(PtrRecord):
     _fields = ['view', 'ipv6addr', 'ptrdname', 'extattrs']
-    _search_fields = ['view', 'ipv6addr']
+    _search_fields = ['view', 'ipv6addr', 'ptrdname']
     _shadow_fields = ['_ref']
     _remap = {'ip': 'ipv6addr'}
     _ip_version = 6

--- a/tests/test_object_manager.py
+++ b/tests/test_object_manager.py
@@ -421,6 +421,7 @@ class ObjectManagerTestCase(unittest.TestCase):
         exp_for_a = {'view': dns_view_name,
                      'ipv4addr': ip}
         exp_for_ptr = {'view': dns_view_name,
+                       'ptrdname': name,
                        'ipv4addr': ip}
         calls = [mock.call('record:a', exp_for_a, return_fields=mock.ANY),
                  mock.call('record:ptr', exp_for_ptr, return_fields=mock.ANY)]


### PR DESCRIPTION
I was having timeout issues searching by ipv4addr.  I've noticed in my environment, searching by ptrdname is much faster.