### PR TITLE
Fix IP allocator to reuse IP with same MAC/Range

### DIFF
--- a/infoblox_client/object_manager.py
+++ b/infoblox_client/object_manager.py
@@ -247,6 +247,10 @@ class InfobloxObjectManager(object):
         if fixed_address:
             fixed_address.delete()
 
+    def get_fixed_addresses_by_mac(self, network_view, mac):
+        return obj.FixedAddress.search_all(
+            self.connector, network_view=network_view, mac=mac)
+
     def add_ip_to_record(self, host_record, ip, mac, use_dhcp=True):
         ip_obj = obj.IP.create(ip=ip, mac=mac, configure_for_dhcp=use_dhcp)
         host_record.ip.append(ip_obj)

--- a/tests/test_object_manager.py
+++ b/tests/test_object_manager.py
@@ -604,6 +604,20 @@ class ObjectManagerTestCase(unittest.TestCase):
             return_fields=mock.ANY, force_proxy=mock.ANY)
         self.assertFalse(connector.delete_object.called)
 
+    @mock.patch('infoblox_client.objects.FixedAddress')
+    def test_get_fixed_addresses_by_mac(self, fixed_address_mock):
+        network_view = 'test_network_view'
+        mac = 'aa:bb:cc:dd:ee:ff'
+        test_result = 'test_result'
+        connector = mock.Mock()
+        ibom = om.InfobloxObjectManager(connector)
+        fixed_address_mock.search_all.return_value = test_result
+
+        res = ibom.get_fixed_addresses_by_mac(network_view, mac)
+        assert res == test_result
+        fixed_address_mock.search_all.assert_called_once_with(
+            connector, network_view=network_view, mac=mac)
+
     def test_member_is_assigned_as_list_on_network_create(self):
         net_view = 'net-view-name'
         cidr = '192.168.1.0/24'


### PR DESCRIPTION
If port creation failed after ip allocation - allocated address
does not removed, so next attempt to create port with same MAC failed.
This fix search fixed addresses with given MAC and if exists fixed
address from given range - use this address instead allocation new one.

Closes-Bug: 1628517