### PR TITLE
Add search HostRecords by MAC

### DIFF
--- a/infoblox_client/objects.py
+++ b/infoblox_client/objects.py
@@ -531,8 +531,9 @@ class HostRecord(InfobloxObject):
 class HostRecordV4(HostRecord):
     """HostRecord for IPv4"""
     _fields = ['ipv4addrs', 'view', 'extattrs', 'name', 'zone',
-               'configure_for_dns', 'network_view']
-    _search_fields = ['view', 'ipv4addr', 'name', 'zone', 'network_view']
+               'configure_for_dns', 'network_view', 'mac']
+    _search_fields = ['view', 'ipv4addr', 'name', 'zone', 'network_view',
+                      'mac']
     _updateable_search_fields = ['name']
     _shadow_fields = ['_ref', 'ipv4addr']
     _return_fields = ['ipv4addrs', 'extattrs']
@@ -593,6 +594,15 @@ class HostRecordV6(HostRecord):
         return [IPv6.from_dict(ip_addr) for ip_addr in ips_v6]
 
     _custom_field_processing = {'ipv6addrs': _build_ipv6.__func__}
+
+
+class IPv6HostAddress(InfobloxObject):
+    _infoblox_type = 'record:host_ipv6addr'
+    _fields = ['duid', 'network_view', 'host']
+    _search_fields = ['duid', 'network_view']
+    _shadow_fields = ['_ref']
+    _return_fields = ['host']
+    _ip_version = 6
 
 
 class SubObjects(BaseObject):

--- a/tests/test_object_manager.py
+++ b/tests/test_object_manager.py
@@ -367,6 +367,36 @@ class ObjectManagerTestCase(unittest.TestCase):
             extattrs=None, force_proxy=mock.ANY, return_fields=mock.ANY,
             max_results=None)
 
+    def test_find_host_records_by_mac(self):
+        dns_view_name = 'dns-view-name'
+        network_view_name = 'network-view-name'
+        mac = '11:22:33:44:55:66'
+        host_name = 'test_host_name'
+
+        connector = mock.Mock()
+        connector.get_object.return_value = [{'host': host_name}]
+        ibom = om.InfobloxObjectManager(connector)
+
+        ibom.find_host_records_by_mac(dns_view_name, mac, network_view_name)
+
+        assert connector.get_object.call_args_list == [
+            mock.call('record:host',
+                      {'view': dns_view_name, 'mac': mac,
+                       'network_view': network_view_name},
+                      extattrs=None, force_proxy=mock.ANY,
+                      return_fields=mock.ANY, max_results=None),
+            mock.call('record:host_ipv6addr',
+                      {'network_view': 'network-view-name',
+                       'duid': '11:22:33:44:55:66'},
+                      extattrs=None, force_proxy=mock.ANY,
+                      return_fields=mock.ANY, max_results=None),
+            mock.call('record:host',
+                      {'name': 'test_host_name',
+                       'network_view': 'network-view-name',
+                       'view': 'dns-view-name'},
+                      extattrs=None, force_proxy=mock.ANY,
+                      return_fields=mock.ANY, max_results=None)]
+
     def _check_bind_names_calls(self, args, expected_get, expected_update):
         connector = mock.Mock()
         connector.get_object.return_value = mock.MagicMock()


### PR DESCRIPTION
Networking-infoblox need ability to search HostRecords by MAC address.
Thi fix added code to support search HostRecords by MAC.
