### PR TITLE
Remove ptrdname from PTR record search attributes

### DIFF
--- a/infoblox_client/objects.py
+++ b/infoblox_client/objects.py
@@ -838,7 +838,7 @@ class PtrRecord(InfobloxObject):
 
 class PtrRecordV4(PtrRecord):
     _fields = ['view', 'ipv4addr', 'ptrdname', 'extattrs']
-    _search_fields = ['view', 'ipv4addr', 'ptrdname']
+    _search_fields = ['view', 'ipv4addr']
     _shadow_fields = ['_ref']
     _remap = {'ip': 'ipv4addr'}
     _ip_version = 4
@@ -846,7 +846,7 @@ class PtrRecordV4(PtrRecord):
 
 class PtrRecordV6(PtrRecord):
     _fields = ['view', 'ipv6addr', 'ptrdname', 'extattrs']
-    _search_fields = ['view', 'ipv6addr', 'ptrdname']
+    _search_fields = ['view', 'ipv6addr']
     _shadow_fields = ['_ref']
     _remap = {'ip': 'ipv6addr'}
     _ip_version = 6

--- a/tests/test_object_manager.py
+++ b/tests/test_object_manager.py
@@ -451,7 +451,6 @@ class ObjectManagerTestCase(unittest.TestCase):
         exp_for_a = {'view': dns_view_name,
                      'ipv4addr': ip}
         exp_for_ptr = {'view': dns_view_name,
-                       'ptrdname': name,
                        'ipv4addr': ip}
         calls = [mock.call('record:a', exp_for_a, return_fields=mock.ANY),
                  mock.call('record:ptr', exp_for_ptr, return_fields=mock.ANY)]


### PR DESCRIPTION
PR https://github.com/infobloxopen/infoblox-client/pull/130 added
ptrdname to PTR record search attribtes. Unfortunately, the
associated behavior resulted in a regression for networking-infoblox.

This PR simply reverts the change.