### PR TITLE
Add _return_fields to SRVRecord

### DIFF
--- a/infoblox_client/objects.py
+++ b/infoblox_client/objects.py
@@ -884,6 +884,7 @@ class SRVRecord(InfobloxObject):
                                  'name', 'port', 'priority', 'reclaimable',
                                  'target', 'view', 'weight', 'zone']
     _all_searchable_fields = _search_for_update_fields
+    _return_fields = ['name', 'port', 'priority', 'weight', 'target', 'view']
     _shadow_fields = ['_ref']
 
 


### PR DESCRIPTION
I'm trying to use SRVRecord objects and am seeing `objects.SRVRecord.create` return different fields depending on if the object exists or not.

If the SRVRecord does exist, `create` fetches the object and returns the fields `_ref, name, target, priority, weight, port, view`.

If the SRVRecord doesn't exist, `create` creates the object, parses the reply with `_object_from_reply` and returns just `_ref`.

For my purposes I'd like `create` to return at least `name, port, priority, weight, target` regardless of if the record already exists. I think the right way to do that is by specifying these in `_return_fields`, and I thought it wouldn't hurt to have `view` there too.

Thanks for any feedback you can offer, and happy holidays!