### PR TITLE
Add comment to Network Class

### DIFF
--- a/infoblox_client/objects.py
+++ b/infoblox_client/objects.py
@@ -448,12 +448,12 @@ class InfobloxObject(BaseObject):
 
 class Network(InfobloxObject):
     _fields = ['network_view', 'network', 'template',
-               'options', 'members', 'extattrs']
+               'options', 'members', 'extattrs', 'comment']
     _search_for_update_fields = ['network_view', 'network']
     _all_searchable_fields = _search_for_update_fields
     _shadow_fields = ['_ref']
     _return_fields = ['network_view', 'network', 'options', 'members',
-                      'extattrs']
+                      'extattrs', 'comment']
     _remap = {'cidr': 'network'}
 
     @classmethod


### PR DESCRIPTION
Perhaps I am misunderstanding `_return_fields` as I would expect the list to be larger. For example most Class's do not have comment in there. 