### PR TITLE
Bump version to 0.4.17

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,7 +3,7 @@
 History
 -------
 
-0.4.16 (2017-11-09)
+0.4.17 (2017-11-09)
 ___________________
 
 * Added pagination support for wapi calls

--- a/infoblox_client/__init__.py
+++ b/infoblox_client/__init__.py
@@ -1,3 +1,3 @@
 __author__ = 'John Belamaric'
 __email__ = 'jbelamaric@infoblox.com'
-__version__ = '0.4.16'
+__version__ = '0.4.17'

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ with open('testing_requirements.txt') as requirements_file:
 
 setup(
     name='infoblox-client',
-    version='0.4.16',
+    version='0.4.17',
     description="Client for interacting with Infoblox NIOS over WAPI",
     long_description=readme + '\n\n' + history,
     author="John Belamaric",


### PR DESCRIPTION
By mistake i deleted pypi version 0.4.16 and we cannot reuse removed version so creating new patch with bumped version 0.4.17