### PR TITLE
Add a few fields useful for DHCP Network and Range creation

### DIFF
--- a/infoblox_client/objects.py
+++ b/infoblox_client/objects.py
@@ -451,7 +451,8 @@ class InfobloxObject(BaseObject):
 
 class Network(InfobloxObject):
     _fields = ['network_view', 'network', 'template',
-               'options', 'members', 'extattrs', 'comment']
+               'options', 'members', 'extattrs', 'comment',
+               'zone_associations']
     _search_for_update_fields = ['network_view', 'network']
     _all_searchable_fields = _search_for_update_fields
     _shadow_fields = ['_ref']


### PR DESCRIPTION
Network
-> zone_assiociations
IPRange
-> server_association_type
-> failover_association

One use case it to map IPRange to failover cluster with:
server_association_type='FAILOVER'
failover_association='YOUR_FAILOVER_CLUSTER_NAME'