### PR TITLE
Disable SSL Verification in Request Options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
   - TOXENV=py27
   - TOXENV=py34
   - TOXENV=py35
+  - TOXENV=py36
   - TOXENV=pep8
 
 install: pip install -U tox

--- a/infoblox_client/connector.py
+++ b/infoblox_client/connector.py
@@ -190,7 +190,8 @@ class Connector(object):
 
     def _get_request_options(self, data=None):
         opts = dict(timeout=self.http_request_timeout,
-                    headers=self.DEFAULT_HEADER)
+                    headers=self.DEFAULT_HEADER,
+                    verify=self.session.verify)
         if data:
             opts['data'] = jsonutils.dumps(data)
         return opts

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ with open('testing_requirements.txt') as requirements_file:
 
 setup(
     name='infoblox-client',
-    version='0.4.19',
+    version='0.4.19-disable_ssl_verify',
     description="Client for interacting with Infoblox NIOS over WAPI",
     long_description=readme + '\n\n' + history,
     author="John Belamaric",

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ with open('testing_requirements.txt') as requirements_file:
 
 setup(
     name='infoblox-client',
-    version='0.4.19-disable_ssl_verify',
+    version='0.4.19',
     description="Client for interacting with Infoblox NIOS over WAPI",
     long_description=readme + '\n\n' + history,
     author="John Belamaric",

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -62,6 +62,7 @@ class TestInfobloxConnector(unittest.TestCase):
                 data=jsonutils.dumps(payload),
                 headers=self.connector.DEFAULT_HEADER,
                 timeout=self.default_opts.http_request_timeout,
+                verify=self.default_opts.ssl_verify,
             )
 
     def test_create_object_with_extattrs(self):
@@ -78,6 +79,7 @@ class TestInfobloxConnector(unittest.TestCase):
                 data=jsonutils.dumps(payload),
                 headers=self.connector.DEFAULT_HEADER,
                 timeout=self.default_opts.http_request_timeout,
+                verify=self.default_opts.ssl_verify,
             )
 
     def test_create_object_raises_member_assigned(self):
@@ -109,6 +111,7 @@ class TestInfobloxConnector(unittest.TestCase):
                 'https://infoblox.example.org/wapi/v1.1/network?ip=0.0.0.0',
                 headers=self.connector.DEFAULT_HEADER,
                 timeout=self.default_opts.http_request_timeout,
+                verify=self.default_opts.ssl_verify,
             )
 
     def test_get_objects_with_extattrs(self):
@@ -127,6 +130,7 @@ class TestInfobloxConnector(unittest.TestCase):
                 'v1.1/network?%2ASubnet+ID=fake_subnet_id&ip=0.0.0.0',
                 headers=self.connector.DEFAULT_HEADER,
                 timeout=self.default_opts.http_request_timeout,
+                verify=self.default_opts.ssl_verify,
             )
 
     def test_get_objects_with_max_results(self):
@@ -141,6 +145,7 @@ class TestInfobloxConnector(unittest.TestCase):
                 'v1.1/network?_max_results=20',
                 headers=self.connector.DEFAULT_HEADER,
                 timeout=self.default_opts.http_request_timeout,
+                verify=self.default_opts.ssl_verify,
             )
 
     def test_get_objects_with_max_results_as_connector_opt(self):
@@ -159,6 +164,7 @@ class TestInfobloxConnector(unittest.TestCase):
                 'v1.1/network?_max_results=10',
                 headers=self.connector.DEFAULT_HEADER,
                 timeout=self.default_opts.http_request_timeout,
+                verify=self.default_opts.ssl_verify,
             )
 
     def test_max_results_priority(self):
@@ -179,6 +185,7 @@ class TestInfobloxConnector(unittest.TestCase):
                 'v1.1/network?_max_results=-20',
                 headers=self.connector.DEFAULT_HEADER,
                 timeout=self.default_opts.http_request_timeout,
+                verify=self.default_opts.ssl_verify,
             )
 
     def test_update_object(self):
@@ -195,6 +202,7 @@ class TestInfobloxConnector(unittest.TestCase):
                 data=jsonutils.dumps(payload),
                 headers=self.connector.DEFAULT_HEADER,
                 timeout=self.default_opts.http_request_timeout,
+                verify=self.default_opts.ssl_verify,
             )
 
     def test_update_object_with_http_error(self):
@@ -230,6 +238,7 @@ class TestInfobloxConnector(unittest.TestCase):
                 'https://infoblox.example.org/wapi/v1.1/network',
                 headers=self.connector.DEFAULT_HEADER,
                 timeout=self.default_opts.http_request_timeout,
+                verify=self.default_opts.ssl_verify,
             )
 
     def test_delete_object_with_http_error(self):
@@ -397,6 +406,7 @@ class TestInfobloxConnector(unittest.TestCase):
                 data=jsonutils.dumps(payload),
                 headers=self.connector.DEFAULT_HEADER,
                 timeout=self.default_opts.http_request_timeout,
+                verify=self.default_opts.ssl_verify,
             )
 
     def test_call_func_with_http_error(self):

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 results = {toxinidir}/test_results/{envname}
 
 [tox]
-envlist = py27, py34, py35, pep8
+envlist = py27, py34, py35, py36, pep8
 
 [testenv]
 deps =


### PR DESCRIPTION
undo change from 3c5629e519f82b501d545d54099d7087124704eb

From my testing with python-3.6, disabling SSL Verification on the session still attempts to verify certificates.