### PR TITLE
Requests no longer vendors urllib3

### DIFF
--- a/infoblox_client/connector.py
+++ b/infoblox_client/connector.py
@@ -19,6 +19,7 @@ import requests
 from requests import exceptions as req_exc
 import six
 import urllib
+import urllib3
 try:
     import urlparse
 except ImportError:
@@ -119,7 +120,7 @@ class Connector(object):
                                                       strict_mode=False)
 
         if self.silent_ssl_warnings:
-            requests.packages.urllib3.disable_warnings()
+            urllib3.disable_warnings()
 
     def _construct_url(self, relative_path, query_params=None,
                        extattrs=None, force_proxy=False):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 requests>=2.5.2
+urllib3>=1.13
 oslo.serialization>=1.4.0
 oslo.log>=1.8.0
 setuptools>=17.1


### PR DESCRIPTION
Python 2.7.5, RHEL 7.4, requests 2.18.4. Ran into this while trying to use the `nios_*` family of modules in Ansible 2.5.