### PR TITLE
Return IP address after ARecords creation

### DIFF
--- a/infoblox_client/objects.py
+++ b/infoblox_client/objects.py
@@ -844,6 +844,7 @@ class ARecord(ARecordBase):
     _fields = ['ipv4addr', 'name', 'view', 'extattrs']
     _search_for_update_fields = ['ipv4addr', 'view']
     _all_searchable_fields = _search_for_update_fields + ['name']
+    _return_fields = _fields
     _shadow_fields = ['_ref']
     _remap = {'ip': 'ipv4addr'}
     _ip_version = 4

--- a/infoblox_client/objects.py
+++ b/infoblox_client/objects.py
@@ -844,7 +844,7 @@ class ARecord(ARecordBase):
     _fields = ['ipv4addr', 'name', 'view', 'extattrs']
     _search_for_update_fields = ['ipv4addr', 'view']
     _all_searchable_fields = _search_for_update_fields + ['name']
-    _return_fields = _fields
+    _return_fields = ['ipv4addr', 'name']
     _shadow_fields = ['_ref']
     _remap = {'ip': 'ipv4addr'}
     _ip_version = 4
@@ -855,6 +855,7 @@ class AAAARecord(ARecordBase):
     _fields = ['ipv6addr', 'name', 'view', 'extattrs']
     _search_for_update_fields = ['ipv6addr', 'view']
     _all_searchable_fields = _search_for_update_fields + ['name']
+    _return_fields = ['ipv6addr', 'name']
     _shadow_fields = ['_ref']
     _remap = {'ip': 'ipv6addr'}
     _ip_version = 6


### PR DESCRIPTION
When an object is created the return fields does not
return the IP address.

In the case you use the func:nextavailableip help function
it enforce to do a lookup of the current retrieved _ref
to retrieve the newly created IP.

Using _fields as _return_fields fix this issue.