### PR TITLE
Allow IPAllocation to be used as ip for ARecord creation

### DIFF
--- a/infoblox_client/objects.py
+++ b/infoblox_client/objects.py
@@ -849,6 +849,16 @@ class ARecord(ARecordBase):
     _remap = {'ip': 'ipv4addr'}
     _ip_version = 4
 
+    @property
+    def ipv4addr(self):
+        # Convert IPAllocation objects to string
+        if hasattr(self, '_ipv4addr'):
+            return str(self._ipv4addr)
+
+    @ipv4addr.setter
+    def ipv4addr(self, ipv4addr):
+        self._ipv4addr = ipv4addr
+
 
 class AAAARecord(ARecordBase):
     _infoblox_type = 'record:aaaa'
@@ -859,6 +869,16 @@ class AAAARecord(ARecordBase):
     _shadow_fields = ['_ref']
     _remap = {'ip': 'ipv6addr'}
     _ip_version = 6
+
+    @property
+    def ipv6addr(self):
+        # Convert IPAllocation objects to string
+        if hasattr(self, '_ipv6addr'):
+            return str(self._ipv6addr)
+
+    @ipv6addr.setter
+    def ipv6addr(self, ipv6addr):
+        self._ipv6addr = ipv6addr
 
 
 class PtrRecord(InfobloxObject):

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -404,6 +404,25 @@ class TestObjects(unittest.TestCase):
             {'name': 'some-new_name'},
             mock.ANY)
 
+    def test_update_fields_on_create_v6(self):
+        aaaa_record = [{'_ref': 'record:aaaa/Awsdrefsasdwqoijvoriibtrni',
+                     'ip': '2001:610:240:22::c100:68b',
+                     'name': 'other_name'}]
+        connector = self._mock_connector(get_object=aaaa_record)
+        objects.ARecordBase.create(connector,
+                                   ip='2001:610:240:22::c100:68b',
+                                   name='some-new_name',
+                                   view='view',
+                                   update_if_exists=True)
+        connector.get_object.assert_called_once_with(
+            'record:aaaa',
+            {'view': 'view', 'ipv6addr': '2001:610:240:22::c100:68b'},
+            return_fields=[])
+        connector.update_object.assert_called_once_with(
+            aaaa_record[0]['_ref'],
+            {'name': 'some-new_name'},
+            mock.ANY)
+
     def test_ip_version(self):
         conn = mock.Mock()
         net_v4 = objects.Network(conn, network='192.168.1.0/24')


### PR DESCRIPTION
This patch tries to follow the current implement scheme
for IP creation with IPAllocation object as an IP.
(As documented in the README.rst)

As ip / ipvXaddr could be an IPallocation object this patch
defines a getter/setter on ipvXaddr to ensure IPAllocation
is converted to string