### PR TITLE
This commit contains changes that takes care when user enters a

### DIFF
--- a/infoblox_client/feature.py
+++ b/infoblox_client/feature.py
@@ -14,7 +14,6 @@
 #    under the License.
 
 import six
-import string
 
 from infoblox_client import exceptions as ib_ex
 
@@ -99,7 +98,7 @@ class WapiVersionUtil(object):
         if (not parts or len(parts) > 3 or len(parts) < 2):
             raise ValueError("Invalid argument was passed")
         for p in parts:
-            if not len(p) or p not in string.digits:
+            if not len(p) or not p.isdigit():
                 raise ValueError("Invalid argument was passed")
         parts = [int(x) for x in parts]
         if len(parts) == 2:


### PR DESCRIPTION
wapi version above 2.9.Examle :2.10.
previously we were using string.digits which was taking value between "0-9".
 so when a value of "10" or above was entered we were getting error

@adsri please review