### PR TITLE
Added possibility for a 'default' flag in return fields, reflecting WAPI

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -15,5 +15,6 @@ Contributors
 * Yue Ko <yko@infoblox.com>
 * Robert Grant <rhgrant10@gmail.com>
 * Yakau Bubnou <yakau_bubnou@epam.com>
+* Jonas Krüger Svensson <jonas-ks@hotmail.com>
 
 More are always welcome!

--- a/README.rst
+++ b/README.rst
@@ -254,7 +254,7 @@ Utilizing extensible attributes and searching on them can easily be done with th
 The ``default`` field in ``return_fields`` acts like the ``+`` does in WAPI.
 
  > ``_return_fields+`` Specified list of fields (comma separated) will be returned in addition
-to the basic fields of the object (documented for each object).
+ to the basic fields of the object (documented for each object).
 
 This enables you to always get the default values in return, in addition to what you specify whether
 you search for a ``network`` or a ``networkcontainer``,

--- a/README.rst
+++ b/README.rst
@@ -246,6 +246,101 @@ Find all host records that starts with '10.10.':
   conn = connector.Connector(opts)
   hr = conn.get_object('record:host', {'ipv4addr~': '10.10.'})
 
+
+More examples
+-------------
+
+Utilizing extensible attributes and searching on them can easily be done with the ``get_object`` function.
+The ``default`` field in ``return_fields`` acts like the ``+`` does in WAPI.
+
+> ``_return_fields+`` Specified list of fields (comma separated) will be returned in addition
+to the basic fields of the object (documented for each object).
+
+This enables you to always get the default values in return, in addition to what you specify whether
+you search for a ``network`` or a ``networkcontainer``,
+defined as ``place_to_check`` in the code below.
+
+
+.. code:: python
+
+    from infoblox_client.connector import Connector
+
+
+    def default_infoblox_connection():
+        opts = {'host': '192.168.1.10', 'username': 'admin', 'password': 'admin'}
+        conn = Connector(opts)
+        return conn
+
+    def search_extensible_attribute(connection, place_to_check: str, extensible_attribute: str, value: str):
+        """
+        Find extensible attributes.
+        :param connection: Infoblox connection
+        :param place_to_check: Can be `network`, `networkcontainer` or `record:host` and so on.
+        :param extensible_attribute: Which extensible attribute to search for. Can be `CustomerCode`, `Location`
+        and so on.
+        :param value: The value you want to search for.
+        :return: result
+        """
+        extensible_args = [
+            place_to_check,
+            {
+                f"*{extensible_attribute}:~": value,
+            }
+        ]
+        kwargs = {
+            'return_fields': [
+                'default',
+                'extattrs',
+            ]
+        }
+        result = {"type": f"{place_to_check}", "objects": connection.get_object(*extensible_args, **kwargs)}
+        return result
+
+    connection = default_infoblox_connection()
+
+    search_network = search_extensible_attribute(connection, "network", "CustomerCode", "Infoblox")
+    {
+      "type": "network",
+      "objects": [
+        {
+          "_ref": "network/ZG5zLmhvc3QkLjQuY29tLm15X3pvbmUubXlfaG9zdF9yZWNvcmQ:192.168.1.1/28/default",
+          "comment": "Infoblox Network",
+          "extattrs": {
+            "CustomerCode": {
+              "value": "Infoblox"
+            }
+          },
+          "network": "192.168.1.0/28",
+          "network_view": "default"
+        }
+      ]
+    }
+
+    search_host = search_extensible_attribute(connection, "record:host", "CustomerCode", "Infoblox")
+    {
+      "type": "record:host",
+      "objects": [
+        {
+          "_ref": "record:host/ZG5zLm5ldHdvcmtfdmlldyQw:InfobloxHost",
+          "extattrs": {
+            "CustomerCode": {
+              "value": "Infoblox"
+            }
+          },
+          "ipv4addrs": [
+            {
+              "_ref": "record:host_ipv4addr/ZG5zLm5ldHdvcmtfdmlldyQwdvcmtfdmlldyQw:192.168.1.1/InfobloxHost",
+              "configure_for_dhcp": false,
+              "host": "InfobloxHost",
+              "ipv4addr": "192.168.1.1"
+            }
+          ],
+          "name": "InfobloxHost",
+          "view": " "
+        }
+      ]
+    }
+
 Features
 --------
 

--- a/README.rst
+++ b/README.rst
@@ -299,6 +299,8 @@ defined as ``place_to_check`` in the code below.
     connection = default_infoblox_connection()
 
     search_network = search_extensible_attribute(connection, "network", "CustomerCode", "Infoblox")
+    # Print the output:
+    print(search_network)
     {
       "type": "network",
       "objects": [
@@ -317,6 +319,8 @@ defined as ``place_to_check`` in the code below.
     }
 
     search_host = search_extensible_attribute(connection, "record:host", "CustomerCode", "Infoblox")
+    # Print the output:
+    print(search_host)
     {
       "type": "record:host",
       "objects": [

--- a/README.rst
+++ b/README.rst
@@ -253,7 +253,7 @@ More examples
 Utilizing extensible attributes and searching on them can easily be done with the ``get_object`` function.
 The ``default`` field in ``return_fields`` acts like the ``+`` does in WAPI.
 
-> ``_return_fields+`` Specified list of fields (comma separated) will be returned in addition
+ > ``_return_fields+`` Specified list of fields (comma separated) will be returned in addition
 to the basic fields of the object (documented for each object).
 
 This enables you to always get the default values in return, in addition to what you specify whether

--- a/infoblox_client/connector.py
+++ b/infoblox_client/connector.py
@@ -178,7 +178,11 @@ class Connector(object):
             query_params = dict()
 
         if return_fields:
-            query_params['_return_fields'] = ','.join(return_fields)
+            if 'default' in return_fields:
+                return_fields.remove('default')
+                query_params['_return_fields+'] = ','.join(return_fields)
+            else:
+                query_params['_return_fields'] = ','.join(return_fields)
 
         if max_results:
             query_params['_max_results'] = max_results

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -133,6 +133,29 @@ class TestInfobloxConnector(unittest.TestCase):
                 verify=self.default_opts.ssl_verify,
             )
 
+    def test_get_object_with_default_and_extattrs(self):
+        objtype = 'network'
+        extattrs = {'Subnet ID': {'value': 'fake_subnet_id'}}
+        return_fields = ['default', 'extattrs']
+
+        with patch.object(requests.Session, 'get',
+                          return_value=mock.Mock()) as patched_get:
+            patched_get.return_value.status_code = 200
+            patched_get.return_value.content = '{}'
+            self.connector.get_object(
+                objtype,
+                extattrs=extattrs,
+                return_fields=return_fields
+            )
+            patched_get.assert_called_once_with(
+                'https://infoblox.example.org/wapi/v1.1/'
+                'network?%2ASubnet+ID=fake_subnet_id'
+                '&_return_fields%2B=extattrs',
+                headers=self.connector.DEFAULT_HEADER,
+                timeout=self.default_opts.http_request_timeout,
+                verify=self.default_opts.ssl_verify,
+            )
+
     def test_get_objects_with_max_results(self):
         objtype = 'network'
         with patch.object(requests.Session, 'get',

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -156,6 +156,30 @@ class TestInfobloxConnector(unittest.TestCase):
                 verify=self.default_opts.ssl_verify,
             )
 
+    def test_get_object_with_specific_return_fields(self):
+        objtype = 'network'
+        extattrs = {'Subnet ID': {'value': 'fake_subnet_id'}}
+        return_fields = ['extattrs']
+
+        with patch.object(requests.Session, 'get',
+                          return_value=mock.Mock()) as patched_get:
+            patched_get.return_value.status_code = 200
+            patched_get.return_value.content = '{}'
+            self.connector.get_object(
+                objtype,
+                extattrs=extattrs,
+                return_fields=return_fields
+            )
+            patched_get.assert_called_once_with(
+                'https://infoblox.example.org/wapi/v1.1/'
+                'network?%2ASubnet+ID=fake_subnet_id'
+                '&_return_fields=extattrs',
+                headers=self.connector.DEFAULT_HEADER,
+                timeout=self.default_opts.http_request_timeout,
+                verify=self.default_opts.ssl_verify,
+            )
+
+
     def test_get_objects_with_max_results(self):
         objtype = 'network'
         with patch.object(requests.Session, 'get',


### PR DESCRIPTION
We have created functionality to search in Infoblox, and in addition to default fields, we would like to have extendable attributes on all elements. This is done by adding a `+` sign after `_return_fields` in WAPI, but is to my knowledge not possible in Infoblox-Client. 

This change enables users to get both the default fields AND the specified extra fields. This reflects how the WAPI works.


Example code to get default fields + extra return_fields below:
```py
def search_extensible_attribute(connection, place_to_check: str, extensible_attribute: str, value: str):
    """
    Find extendible attributes. Async method
    :param connection: Infoblox connection
    :param place_to_check: Can be `network`, `networkcontainer` or `record:host` and so on.
    :param extensible_attribute: Which extensible attribute to search for. 
    :param value: The value you want to search for.
    :return: result
    """
    extensible_args = [
        place_to_check,  
        {
            f"*{extensible_attribute}:~": f"{value}",
        }
    ]
    kwargs = {
        'return_fields': [
            'default',
            'extattrs',
        ]
    }

    result = {f"{place_to_check}": connection.get_object(*extensible_args, **kwargs)}
    return result
```
