### PR TITLE
Changed to able to get/update 'aliases' parameter of HOST record for DNS

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -15,5 +15,6 @@ Contributors
 * Yue Ko <yko@infoblox.com>
 * Robert Grant <rhgrant10@gmail.com>
 * Yakau Bubnou <yakau_bubnou@epam.com>
+* Hiroyasu OHYAMA <user.localhost2000@gmail.com>
 
 More are always welcome!

--- a/infoblox_client/objects.py
+++ b/infoblox_client/objects.py
@@ -555,13 +555,13 @@ class HostRecordV4(HostRecord):
     """HostRecord for IPv4"""
     _fields = ['ipv4addrs', 'view', 'extattrs', 'name', 'zone',
                'configure_for_dns', 'network_view', 'mac', 'ttl',
-               'comment']
+               'comment', 'aliases']
     _search_for_update_fields = ['view', 'ipv4addr', 'name',
                                  'zone', 'network_view', 'mac']
     _all_searchable_fields = _search_for_update_fields
     _updateable_search_fields = ['name']
     _shadow_fields = ['_ref', 'ipv4addr']
-    _return_fields = ['ipv4addrs', 'extattrs']
+    _return_fields = ['ipv4addrs', 'extattrs', 'aliases']
     _remap = {'ip': 'ipv4addrs',
               'ips': 'ipv4addrs'}
     _ip_version = 4
@@ -590,13 +590,14 @@ class HostRecordV4(HostRecord):
 class HostRecordV6(HostRecord):
     """HostRecord for IPv6"""
     _fields = ['ipv6addrs', 'view', 'extattrs',  'name', 'zone',
-               'configure_for_dns', 'network_view', 'ttl', 'comment']
+               'configure_for_dns', 'network_view', 'ttl', 'comment',
+               'aliases']
     _search_for_update_fields = ['ipv6addr', 'view', 'name',
                                  'zone', 'network_view']
     _all_searchable_fields = _search_for_update_fields
     _updateable_search_fields = ['name']
     _shadow_fields = ['_ref', 'ipv6addr']
-    _return_fields = ['ipv6addrs', 'extattrs']
+    _return_fields = ['ipv6addrs', 'extattrs', 'aliases']
     _remap = {'ip': 'ipv6addrs',
               'ips': 'ipv6addrs'}
 

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -135,7 +135,7 @@ class TestObjects(unittest.TestCase):
                 {'mac': 'fa:16:3e:29:87:70',
                  'ipv4addr': '22.0.0.2'}],
              'view': 'some-dns-view'},
-            ['ipv4addrs', 'extattrs'])
+            ['ipv4addrs', 'extattrs', 'aliases'])
 
     def test_create_host_record_with_ip(self):
         mock_record = DEFAULT_HOST_RECORD


### PR DESCRIPTION
Thank you make this useful library! Please let me enhance a feature for DNS.

## Background
Current implementation couldn't touch with `aliases` field of HOST record for DNS.

## Change 
This patch enables to get/set it.