### PR TITLE
Use ibapauth cookies for the entire session

### DIFF
--- a/infoblox_client/connector.py
+++ b/infoblox_client/connector.py
@@ -67,8 +67,6 @@ class Connector(object):
                        'paging': False}
 
     def __init__(self, options):
-        self._parse_options(options)
-        self._configure_session()
         # urllib has different interface for py27 and py34
         try:
             self._urlencode = urllib.urlencode
@@ -78,6 +76,8 @@ class Connector(object):
             self._urlencode = urlparse.urlencode
             self._quote = urlparse.quote
             self._urljoin = urlparse.urljoin
+        self._parse_options(options)
+        self._configure_session()
 
     def _parse_options(self, options):
         """Copy needed options to self"""
@@ -121,6 +121,12 @@ class Connector(object):
 
         if self.silent_ssl_warnings:
             urllib3.disable_warnings()
+
+        # this is just to establish the initial ibapauth cookie
+        self.get_object('grid')
+        if(len(self.session.cookies) > 0):
+            # from now on, use cookies instead of username/password
+            self.session.auth = None
 
     def _construct_url(self, relative_path, query_params=None,
                        extattrs=None, force_proxy=False):

--- a/infoblox_client/connector.py
+++ b/infoblox_client/connector.py
@@ -79,7 +79,6 @@ class Connector(object):
             self._quote = urlparse.quote
             self._urljoin = urlparse.urljoin
 
-
     def _parse_options(self, options):
         """Copy needed options to self"""
         attributes = ('host', 'wapi_version', 'username', 'password',

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -488,6 +488,15 @@ class TestInfobloxConnector(unittest.TestCase):
                           self.connector._check_service_availability, "delete",
                           resp, '_ref')
 
+    def test_connection_with_cookies(self):
+        objtype = 'network'
+        with patch.object(requests.Session, 'get',
+                          return_value=mock.Mock()) as patched_get:
+            self.connector.session.cookies = ['cookies']
+            patched_get.return_value.status_code = 200
+            patched_get.return_value.content = '{}'
+            self.connector.get_object(objtype, {})
+            self.assertEqual(None, self.connector.session.auth)
 
 class TestInfobloxConnectorStaticMethods(unittest.TestCase):
     def test_neutron_exception_is_raised_on_any_request_error(self):

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -65,6 +65,7 @@ class TestInfobloxConnector(unittest.TestCase):
                 timeout=self.default_opts.http_request_timeout,
                 verify=self.default_opts.ssl_verify,
             )
+            # test if cookies have been set
             self.assertEqual(None, self.connector.session.auth)
 
     def test_create_object_with_extattrs(self):

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -54,6 +54,7 @@ class TestInfobloxConnector(unittest.TestCase):
 
         with patch.object(requests.Session, 'post',
                           return_value=mock.Mock()) as patched_create:
+            self.connector.session.cookies = ['cookies']
             patched_create.return_value.status_code = 201
             patched_create.return_value.content = '{}'
             self.connector.create_object(objtype, payload)
@@ -64,6 +65,7 @@ class TestInfobloxConnector(unittest.TestCase):
                 timeout=self.default_opts.http_request_timeout,
                 verify=self.default_opts.ssl_verify,
             )
+            self.assertEqual(None, self.connector.session.auth)
 
     def test_create_object_with_extattrs(self):
         objtype = 'network'
@@ -488,7 +490,7 @@ class TestInfobloxConnector(unittest.TestCase):
                           self.connector._check_service_availability, "delete",
                           resp, '_ref')
 
-    def test_connection_with_cookies(self):
+    def test_get_object_with_cookies(self):
         objtype = 'network'
         with patch.object(requests.Session, 'get',
                           return_value=mock.Mock()) as patched_get:


### PR DESCRIPTION
After first login to the API, a session cookie is generated, which can be re-used for every subsequent request, avoiding the need to re-authenticate.

There is an added lag during connector initialization, because that's when the cookie is established, however all subsequent calls are much faster than before.

The use-case which required this change is an environment where authentication to Infoblox uses timed 2FA (two-factor authentication), so the passwords are not static. After a given amount of requests with the same 2FA code, the underlying authentication mechanism starts denying login, causing any subsequent calls to fail. Using the cookie guarantees that the session will remain valid for as long as the value defined for session timeout (same as the web UI session timeout, defined on the grid properties).