### PR TITLE
Dhcp range add some useful fields

### DIFF
--- a/infoblox_client/objects.py
+++ b/infoblox_client/objects.py
@@ -735,7 +735,8 @@ class DhcpOption(SubObjects):
 
 class IPRange(InfobloxObject):
     _fields = ['start_addr', 'end_addr', 'network_view',
-               'network', 'extattrs', 'disable']
+               'network', 'extattrs', 'disable', 'template', 'comment',
+               'server_association_type', 'failover_association']
     _remap = {'cidr': 'network'}
     _search_for_update_fields = ['network_view', 'start_addr',
                                  'end_addr', 'network']


### PR DESCRIPTION
Hi all,

Adding some useful fields to the IPRange object for DHCP ranges.

IPRange
-> template
-> comment
-> server_association_type
-> failover_association

I have tested these on create and search methods, and they appear to work. They don't work on update, but that seems to be a broader issue that I'll open a bug for.
