### PR TITLE
Feature/extend ip address

### DIFF
--- a/infoblox_client/objects.py
+++ b/infoblox_client/objects.py
@@ -984,7 +984,7 @@ class EADefinition(InfobloxObject):
 
 class IPAddress(InfobloxObject):
     _fields = ['network_view', 'ip_address', 'objects', 'network', 'status',
-               'mac_address', 'types', 'usage', 'names']
+               'is_conflict', 'mac_address', 'types', 'usage', 'names']
     _search_for_update_fields = ['network_view', 'ip_address',
                                  'network', 'status']
     _all_searchable_fields = _search_for_update_fields

--- a/infoblox_client/objects.py
+++ b/infoblox_client/objects.py
@@ -983,7 +983,8 @@ class EADefinition(InfobloxObject):
 
 
 class IPAddress(InfobloxObject):
-    _fields = ['network_view', 'ip_address', 'objects', 'network', 'status']
+    _fields = ['network_view', 'ip_address', 'objects', 'network', 'status',
+               'mac_address', 'types', 'usage', 'names']
     _search_for_update_fields = ['network_view', 'ip_address',
                                  'network', 'status']
     _all_searchable_fields = _search_for_update_fields

--- a/infoblox_client/objects.py
+++ b/infoblox_client/objects.py
@@ -1009,6 +1009,7 @@ class IPv4Address(IPAddress):
 class IPv6Address(IPAddress):
     _infoblox_type = 'ipv6address'
     _ip_version = 6
+    _fields = IPAddress._fields + ['duid', 'lease_state']
 
 
 class IPAllocation(object):

--- a/infoblox_client/objects.py
+++ b/infoblox_client/objects.py
@@ -984,7 +984,7 @@ class EADefinition(InfobloxObject):
 
 class IPAddress(InfobloxObject):
     _fields = ['network_view', 'ip_address', 'objects', 'network', 'status',
-               'is_conflict', 'mac_address', 'types', 'usage', 'names']
+               'is_conflict', 'types', 'usage', 'names']
     _search_for_update_fields = ['network_view', 'ip_address',
                                  'network', 'status']
     _all_searchable_fields = _search_for_update_fields
@@ -1003,6 +1003,7 @@ class IPAddress(InfobloxObject):
 class IPv4Address(IPAddress):
     _infoblox_type = 'ipv4address'
     _ip_version = 4
+    _fields = IPAddress._fields + ['mac_address']
 
 
 class IPv6Address(IPAddress):


### PR DESCRIPTION
Request to merge a few more fields to IPAddress.
Those are the default fields returned by infoblox as of v2.1 WAPI.
Default return fields are retrieved when setting return_fields to []

Sample code
`
ipa = objects.IPAddress.search(conn, ip_address='192.168.0.1',
                               return_fields=[])
`
Those are needed on my side to perform compliance checks.