### PR TITLE
Added `ms_server` fields to `FixedAddress`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -139,6 +139,7 @@ Reply from NIOS is parsed back into objects and contains next data:
 Create a new fixed address, with a MS server DHCP reservation:
 
 .. code:: python
+
   obj, created = objects.FixedAddress.create_check_exists(connector=conn,
                                                           ip='192.168.100.100',
                                                           mac='aa:bb:cc:11:22:33',
@@ -147,6 +148,7 @@ Create a new fixed address, with a MS server DHCP reservation:
                                                           network_view='default',
                                                           ms_server={'_struct': 'msdhcpserver',
                                                                      'ipv4addr': '192.168.0.0'})
+
 
 
 High level API, using InfobloxObjectManager

--- a/README.rst
+++ b/README.rst
@@ -101,7 +101,7 @@ Create a host record:
 .. code:: python
 
   my_ip = objects.IP.create(ip='192.168.1.25', mac='aa:bb:cc:11:22:33')
-  hr = objects.HostRecord.create(conn, view='my_dns_view', 
+  hr = objects.HostRecord.create(conn, view='my_dns_view',
                                  name='my_host_record.my_zone.com', ip=my_ip)
 
 Create host record with Extensible Attributes (EA):
@@ -116,7 +116,7 @@ Set the TTL to 30 minutes:
 
 .. code:: python
 
-  hr = objects.HostRecord.create(conn, view='my_dns_view', 
+  hr = objects.HostRecord.create(conn, view='my_dns_view',
                                  name='my_host_record.my_zone.com', ip=my_ip,
                                  ttl = 1800)
 
@@ -134,6 +134,20 @@ Reply from NIOS is parsed back into objects and contains next data:
 
   In [22]: hr
   Out[22]: HostRecordV4: _ref=record:host/ZG5zLmhvc3QkLjQuY29tLm15X3pvbmUubXlfaG9zdF9yZWNvcmQ:my_host_record.my_zone.com/my_dns_view, name=my_host_record.my_zone.com, ipv4addrs=[<infoblox_client.objects.IPv4 object at 0x7f7d6b0fe9d0>], view=my_dns_view
+
+
+Create a new fixed address, with a MS server DHCP reservation:
+
+.. code:: python
+  obj, created = objects.FixedAddress.create_check_exists(connector=conn,
+                                                          ip='192.168.100.100',
+                                                          mac='aa:bb:cc:11:22:33',
+                                                          comment='My DHCP reservation',
+                                                          name='My hostname',
+                                                          network_view='default',
+                                                          ms_server={'_struct': 'msdhcpserver',
+                                                                     'ipv4addr': '192.168.0.0'})
+
 
 High level API, using InfobloxObjectManager
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -157,7 +171,7 @@ All top level objects support interface for CRUD operations. List of supported o
     Creates object on NIOS side.
     Requires connector passed as the first argument, ``check_if_exists`` and ``update_if_exists`` are optional.
     Object related fields are passed in as kwargs: ``field=value``, ``field2=value2``.
-    
+
 - ``search(cls, connector, return_fields=None, search_extattrs=None, force_proxy=False, **kwargs)``
     Search single object on NIOS side, returns first object that match search criteria.
     Requires connector passed as the first argument.
@@ -166,14 +180,14 @@ All top level objects support interface for CRUD operations. List of supported o
     If ``return_fields`` is ``[]`` default ``return_fields`` are returned by NIOS side for current ``wapi_version``.
     ``search_extattrs`` is used to filter out results by extensible attributes.
     ``force_proxy`` forces search request to be processed on Grid Master (applies only in cloud environment)
-    
+
 - ``search_all(cls, connector, return_fields=None, search_extattrs=None, force_proxy=False, **kwargs)``
     Search all objects on NIOS side that match search criteria. Returns a list of objects.
     All other options are equal to ``search()``.
 
 - ``update(self)``
     Update the object on NIOS side by pushing changes done in the local object.
-    
+
 - ``delete(self)``
     Deletes the object from NIOS side.
 
@@ -188,37 +202,37 @@ Supported NIOS objects
 
   * ``NetworkV4`` for 'network'
   * ``NetworkV6`` for 'ipv6network'
-  
+
 * ``IPRange`` (V4 and V6)
-  
+
   * ``IPRangeV4`` for 'range'
   * ``IPRangeV6`` for 'ipv6range'
-  
+
 * ``HostRecord`` (V4 and V6)
 
   * ``HostRecordV4`` for 'record:host'
   * ``HostRecordV6`` for 'record:host'
-  
+
 * ``FixedAddress`` (V4 and V6)
 
   * ``FixedAddressV4`` for 'fixedaddress'
   * ``FixedAddressV6`` for 'ipv6fixedaddress'
-  
+
 * ``IPAddress`` (V4 and V6)
-  
+
   * ``IPv4Address`` for 'ipv4address'
   * ``IPv6Address`` for 'ipv6address'
-  
+
 * ``ARecordBase``
 
   * ``ARecord`` for 'record:a'
   * ``AAAARecord`` for 'record:aaaa'
-   
+
 * ``PtrRecord`` (V4 and V6)
 
   * ``PtrRecordV4`` for 'record:ptr'
   * ``PtrRecordV6`` for 'record:ptr'
-   
+
 * ``EADefinition`` for 'extensibleattributedef'
 * ``CNAMERecord`` for 'record:cname'
 

--- a/infoblox_client/objects.py
+++ b/infoblox_client/objects.py
@@ -786,7 +786,7 @@ class FixedAddress(InfobloxObject):
 class FixedAddressV4(FixedAddress):
     _infoblox_type = 'fixedaddress'
     _fields = ['ipv4addr', 'mac', 'network_view', 'extattrs', 'network',
-               'options', 'comment', 'name']
+               'options', 'comment', 'name', 'ms_server']
     _search_for_update_fields = ['ipv4addr', 'mac', 'network_view', 'network']
     _all_searchable_fields = _search_for_update_fields
     _shadow_fields = ['_ref', 'ip']
@@ -807,7 +807,7 @@ class FixedAddressV6(FixedAddress):
     """FixedAddress for IPv6"""
     _infoblox_type = 'ipv6fixedaddress'
     _fields = ['ipv6addr', 'duid', 'network_view', 'extattrs', 'network',
-               'comment', 'name']
+               'comment', 'name', 'ms_server']
     _search_for_update_fields = ['ipv6addr', 'duid', 'network_view', 'network']
     _all_searchable_fields = _search_for_update_fields
     _return_fields = ['ipv6addr', 'duid', 'network_view', 'extattrs']

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -218,7 +218,8 @@ class TestObjects(unittest.TestCase):
         fixed_addr = objects.FixedAddress.create(connector,
                                                  ip='192.168.1.15',
                                                  network_view='some-view',
-                                                 mac='aa:ac:cd:11:22:33')
+                                                 mac='aa:ac:cd:11:22:33',
+                                                 ms_server={'_struct': 'msdhcpserver', 'ipv4addr': '192.168.1.0'})
         connector.get_object.assert_called_once_with(
             'fixedaddress',
             {'network_view': 'some-view', 'ipv4addr': '192.168.1.15',
@@ -228,7 +229,7 @@ class TestObjects(unittest.TestCase):
         connector.create_object.assert_called_once_with(
             'fixedaddress',
             {'network_view': 'some-view', 'ipv4addr': '192.168.1.15',
-             'mac': 'aa:ac:cd:11:22:33'}, mock.ANY)
+             'mac': 'aa:ac:cd:11:22:33', 'ms_server': {'_struct': 'msdhcpserver', 'ipv4addr': '192.168.1.0'}}, mock.ANY)
 
     def test_create_fixed_address_v6(self):
         mock_fixed_address = {
@@ -241,7 +242,8 @@ class TestObjects(unittest.TestCase):
         fixed_addr = objects.FixedAddress.create(connector,
                                                  ip='fffe:1234:1234::1',
                                                  network_view='some-view',
-                                                 mac='aa:ac:cd:11:22:33')
+                                                 mac='aa:ac:cd:11:22:33',
+                                                 ms_server={'_struct': 'msdhcpserver', 'ipv4addr': '192.168.1.0'})
         self.assertIsInstance(fixed_addr, objects.FixedAddressV6)
         self.assertEqual(mock_fixed_address['duid'], fixed_addr.duid)
 
@@ -253,7 +255,7 @@ class TestObjects(unittest.TestCase):
         connector.create_object.assert_called_once_with(
             'ipv6fixedaddress',
             {'network_view': 'some-view', 'ipv6addr': 'fffe:1234:1234::1',
-             'duid': mock.ANY}, mock.ANY)
+             'duid': mock.ANY,  'ms_server': {'_struct': 'msdhcpserver', 'ipv4addr': '192.168.1.0'}}, mock.ANY)
 
     @mock.patch('infoblox_client.utils.generate_duid')
     def test_fixed_address_v6(self, generate):

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -255,7 +255,7 @@ class TestObjects(unittest.TestCase):
         connector.create_object.assert_called_once_with(
             'ipv6fixedaddress',
             {'network_view': 'some-view', 'ipv6addr': 'fffe:1234:1234::1',
-             'duid': mock.ANY,  'ms_server': {'_struct': 'msdhcpserver', 'ipv4addr': '192.168.1.0'}}, mock.ANY)
+             'duid': mock.ANY, 'ms_server': {'_struct': 'msdhcpserver', 'ipv4addr': '192.168.1.0'}}, mock.ANY)
 
     @mock.patch('infoblox_client.utils.generate_duid')
     def test_fixed_address_v6(self, generate):


### PR DESCRIPTION
New PR due to some messed up rebasing.

Added `ms_server` fields to `FixedAddress`, enabling us to reserve an address on our MS server.

Docs:
```

ms_server¶
The Microsoft server associated with this fixed address.
Type
A/An MS DHCP server struct.

Create
The default value is empty.

Search
The field is available for search via
    ‘=’ (exact equality)
```
Changed tests to include checking this.

Added a tiny doc to have an example on to pass the struct properly.