### PR TITLE
Update six package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-six==1.13.0
+six==1.14.0
 requests>=2.5.2
 urllib3>=1.13
 oslo.serialization>=1.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-six>=1.14.0
+six>=1.11.0
 requests>=2.5.2
 urllib3>=1.13
 oslo.serialization>=1.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-six==1.14.0
+six>=1.14.0
 requests>=2.5.2
 urllib3>=1.13
 oslo.serialization>=1.4.0


### PR DESCRIPTION
This package currently requires `six` version `1.13.0` some third party packages require `1.14.0` or higher,  which can create conflicts in projects. 

I've looked into the changelog, and there doesn't seem to be any breaking changes that would affect this package. 

`six` version `1.14.0` removes support for Python `2.6` and `3.2`, seeing as Python 2 in its entirety is EOL and `3.2` has been EOL since 2015, I don't see this being a problem. 