### PR TITLE
Allow newer versions of six

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-six==1.13.0
+six>=1.13.0
 requests>=2.5.2
 urllib3>=1.13
 oslo.serialization>=1.4.0


### PR DESCRIPTION
Pinning this easily leads to dependency issues when installed with other packages.