### PR TITLE
Revert "#195: Queried PTR Records don't have an IP"

### DIFF
--- a/infoblox_client/objects.py
+++ b/infoblox_client/objects.py
@@ -363,8 +363,6 @@ class InfobloxObject(BaseObject):
     def search(cls, connector, **kwargs):
         ib_obj, parse_class = cls._search(
             connector, **kwargs)
-        if ib_obj and len(ib_obj) > 1 and ib_obj[1]:
-            return parse_class.from_dict(connector, ib_obj[1])
         if ib_obj:
             return parse_class.from_dict(connector, ib_obj[0])
 

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -123,38 +123,6 @@ class TestInfobloxConnector(unittest.TestCase):
                 verify=self.default_opts.ssl_verify,
             )
 
-    def test_get_object_for_ptr_record(self):
-        objtype = 'record:ptr'
-        payload = {'dummy_payload': 'dummy_value'}
-        mocked_ib_object = {
-            u'_ref': u'record:ptr/ZG5zLmJpbmRfcHRyJC5fZGVmYXVsdC5hcnBhLmluLWFkZHIuMzAuMC4wLjIuYWEuY29t:2.0.0.30.in-addr.arpa/default',
-            u'ptrdname': u'foobar.com', 'ipv4addr': None, u'view': u'default'
-        }
-        dummy_ib_object = {
-            u'_ref': u'dummy_string_with_1.2.3.4_as_dummy_ip',
-            u'ptrdname': u'foobar.com', 'ipv4addr': None, u'view': u'default'
-        }
-
-        mocked_ib_object_expected = {
-            u'_ref': u'record:ptr/ZG5zLmJpbmRfcHRyJC5fZGVmYXVsdC5hcnBhLmluLWFkZHIuMzAuMC4wLjIuYWEuY29t:2.0.0.30.in-addr.arpa/default',
-            u'ptrdname': u'foobar.com', 'ipv4addr': '30.0.0.2', u'view': u'default'
-        }
-        dummy_ib_object_expected = {
-            u'_ref': u'dummy_string_with_1.2.3.4_as_dummy_ip',
-            u'ptrdname': u'foobar.com', 'ipv4addr': '4.3.2.1', u'view': u'default'
-        }
-
-        with patch.object(requests.Session, 'get',
-                          return_value=mock.Mock()) as patched_get:
-            patched_get.return_value.status_code = 200
-            patched_get.return_value.content = '{}'
-
-            with patch.object(connector.Connector, '_handle_get_object',
-                                   return_value=[dummy_ib_object, mocked_ib_object]) as patched_handle_get_object:
-                actual = self.connector.get_object(objtype, payload)
-                expected = [dummy_ib_object_expected, mocked_ib_object_expected]
-                self.assertEqual(actual, expected)
-
     def test_get_objects_with_extattrs(self):
         objtype = 'network'
         payload = {'ip': '0.0.0.0'}
@@ -649,7 +617,6 @@ class TestInfobloxConnectorStaticMethods(unittest.TestCase):
                               connector.Connector.is_cloud_wapi,
                               value)
 
-
     def test__parse_reply_raises_connection_error(self):
         request = mock.Mock()
         request.content = ('<HTML><BODY BGCOLOR="FFFFFF">'
@@ -672,21 +639,3 @@ class TestInfobloxConnectorStaticMethods(unittest.TestCase):
 
         parsed_reply = connector.Connector._parse_reply(request)
         self.assertEqual(expected_reply, parsed_reply)
-
-    def test__extract_ip(self):
-        ip_addr = connector.Connector._extract_ip(
-            'record:ptr/ZG5zLmJpbmRfcHRyJC5fZGVmYXVsdC5hcnBhLmluLWFkZHIuMzAuMC4wLjIuYWEuY29t:2.0.0.30.in-addr.arpa/default'
-        )
-        self.assertEqual(ip_addr, '30.0.0.2')
-
-        domain = connector.Connector._extract_ip(
-            'record:ptr/ZG5zLmJpbmRfcHRyJC5fZGVmYXVsdC5jb20udmFpc2guY2hlY2suYWEuY29t:check.dom.com/default'
-        )
-        self.assertEqual(domain, '')
-
-        empty_string = connector.Connector._extract_ip('')
-        self.assertEqual(empty_string, None)
-
-        no_input = connector.Connector._extract_ip(None)
-        self.assertEqual(no_input, None)
-

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -526,26 +526,3 @@ class TestObjects(unittest.TestCase):
         data = {'host_name': 'cp.com',
                 'unknown_field': 'some_data'}
         self.assertEqual(data, objects.Member._remap_fields(data))
-
-    def test_search_ptrrecordv4(self):
-        mocked_ib_object = {
-            u'_ref': u'record:ptr/ZG5zLmJpbmRfcHRyJC5fZGVmYXVsdC5hcnBhLmluLWFkZHIuMzAuMC4wLjIuYWEuY29t:2.0.0.30.in-addr.arpa/default',
-            u'ptrdname': u'foobar.com', 'ipv4addr': u'30.0.0.2', u'view': u'default'
-        }
-        dummy_ib_object = {
-            u'_ref': u'dummy_string',
-            u'ptrdname': u'foobar.com', 'ipv4addr': u'', u'view': u'default'
-        }
-        connector = self._mock_connector(get_object=[mocked_ib_object])
-
-        actual = objects.PtrRecord.search(connector, ptrdname="foobar.com")
-        expected = objects.PtrRecordV4.from_dict(connector, mocked_ib_object)
-        self.assertEqual(actual, expected)
-
-        with mock.patch.object(objects.InfobloxObject, '_search',
-                               return_value=([dummy_ib_object, mocked_ib_object], objects.PtrRecordV4)) as _search_mock:
-            actual = objects.PtrRecord.search(connector, ptrdname="foobar.com")
-            expected = objects.PtrRecordV4.from_dict(connector, mocked_ib_object)
-            self.assertEqual(actual, expected)
-            
-


### PR DESCRIPTION
Reverts infobloxopen/infoblox-client#238

This entire logic needs to be rethinked and redone. It's currently messing up almost all (if not all) `get_object` functions. Every object that does not have `ipv4addr` in it, will now get an extra field with `ipv4addr` appended to it. The code/logic behind the `ipv4addr` extraction also only works where the IP is mirrored in the ref - which basically only happens for PTR records. Obviously this will break on multiple scenarios, including any IPv6.

In practice this means if you do fetch for `network` objects with `get_object` like this:
```py
args = ['network',{'comment~:': '^(mycomment)'}]
kwargs = {
    'return_fields': [
        'comment',
        'network',
    ]
}
response = connection.get_object(*args, **kwargs)
print(response)
```
you'll get the response from Infoblox WAPI(and  `infoblox-client` version `0.4.23`)  looking like this: 
```py
[
 {
    '_ref': 'network/somelongref:10.40.39.0/24/default',
    'comment': 'mycomment',
    'network': '10.40.39.0/24',
  },
]
``` 

How ever, because of this change it will look like this:

```py
[
  {
    '_ref': 'network/somelongref:10.40.39.0/24/default',
    'comment': 'ZU-0D - PROD',
    'network': '10.40.39.0/24',
    'ipv4addr': '0.39.40.10',   # <-- ???
  }
]
``` 
As you can see, every object now gets a property called `ipv4addr` added to it, and the IP is also mirrored. If an object is not returned, hacking it in `get_object` is not the proper solution. Fix the WAPI or implement the logic in `PtrRecordV4` / `PtrRecordV6`. 