### PR TITLE
Set python-six dependency to >=1.11.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-six==1.13.0
+six>=1.11.0
 requests>=2.5.2
 urllib3>=1.13
 oslo.serialization>=1.4.0


### PR DESCRIPTION
Relax python-six dependency to >=1.11.0 because most current long term Linux distros deliver 1.11 or 1.12.
According to this Infoblox forum thread, there should be no side effects:
https://community.infoblox.com/t5/API-Integration/infoblox-client-0-4-24-dependency-question/m-p/19910/highlight/true#M2577