### PR TITLE
Fix a nasty bug when calling abstracted class from_dict with V4 & V6 subclass

### DIFF
--- a/infoblox_client/objects.py
+++ b/infoblox_client/objects.py
@@ -247,13 +247,14 @@ class InfobloxObject(BaseObject):
         _global_field_processing and _custom_field_processing rules
         are checked.
         """
-        mapping = cls._global_field_processing.copy()
-        mapping.update(cls._custom_field_processing)
+        ipv_class = cls.get_class_from_args(ip_dict)
+        mapping = ipv_class._global_field_processing.copy()
+        mapping.update(ipv_class._custom_field_processing)
         # Process fields that require building themselves as objects
         for field in mapping:
             if field in ip_dict:
                 ip_dict[field] = mapping[field](ip_dict[field])
-        return cls(connector, **ip_dict)
+        return ipv_class(connector, **ip_dict)
 
     @staticmethod
     def value_to_dict(value):


### PR DESCRIPTION
Issue:
    When calling objects.NetworkContainer.from_dict(args)
    the _custom_field_processing functions are not called
    For example you get a list of dict for options instead of
    list of Dhcpoption objects

    This applies for all Objects that are subclass with V4 and V6

Root Cause:
    from_dict NetworkContainer class methodis from InfobloxObject from_dict
    classmethod
    This parent class method from_dict is using the NetworkContainer class
    attibutes (And there is none)
    We definitly need to lookup the V4 or V6 subclass first to get
    the class & attributes right