### PR TITLE
Updated connector's urlencoding logic for proper array encoding

### DIFF
--- a/infoblox_client/connector.py
+++ b/infoblox_client/connector.py
@@ -161,7 +161,7 @@ class Connector(object):
         if query_params:
             if len(query) > 1:
                 query += '&'
-            query += self._urlencode(query_params)
+            query += self._urlencode(query_params, doseq=True)
 
         base_url = self._urljoin(self.wapi_url,
                                  self._quote(relative_path))

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -340,6 +340,13 @@ class TestInfobloxConnector(unittest.TestCase):
         self.assertEqual('https://infoblox.example.org/wapi/v1.1/network?%2ASubnet+ID=fake_subnet_id&some_option=some_value',  # noqa: E501
                          url)
 
+    def test_construct_url_with_query_params_containing_array(self):
+        query_params = {'array_option': ['value1', 'value2']}
+        url = self.connector._construct_url('network',
+                                            query_params=query_params)
+        self.assertEqual('https://infoblox.example.org/wapi/v1.1/network?array_option=value1&array_option=value2',  # noqa: E501
+                         url)
+
     def test_construct_url_with_force_proxy(self):
         ext_attrs = {'Subnet ID': {'value': 'fake_subnet_id'}}
         url = self.connector._construct_url('network',


### PR DESCRIPTION
## Issue Description 

The client was unable to perform array-search, because query parameters containing array was URL-encoded like this:
| Parameter | URL-Encoding |
| :---: | :---: |
| `{'array_option': ['value1', 'value2']}` | `...?array_option=%5B%27value1%27%2C+%27value2%27%5D` |

Instead, every entry in an array should be URL-encoded as a separate key/value pair. Like this:
| Parameter | URL-Encoding |
| :---: | :---: |
| `{'array_option': ['value1', 'value2']}` | `...?array_option=value1&array_option=value2` |

## How It Was Fixed

* Added [`doseq=True`](https://docs.python.org/3/library/urllib.parse.html#urllib.parse.urlencode) parameter to `Connector`'s `_urlencode` method call.

* Now arrays in query params will be URL-encoded as a set of key/value pairs.
  Each key/value will represent an entry in the respective array.

* This will make array-search possible.

## Unit Tests

- `test_construct_url_with_query_params_containing_array` -- checks if `Connector`'s `_construct_url` method encodes array as it was described earlier. 