### PR TITLE
Updated Connector's method to raise exception if API response status is incorrect

### DIFF
--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -605,11 +605,6 @@ class TestInfobloxConnector(unittest.TestCase):
             self.connector.get_object(objtype, {})
             self.assertEqual(None, self.connector.session.auth)
 
-    # def test__get_object_raises_not_found(self):
-    #     self.connector.session.get = mock.MagicMock(
-    #         return_value=requests.request('GET', )
-    #     )
-
 
 class TestInfobloxConnectorStaticMethods(unittest.TestCase):
     def test_neutron_exception_is_raised_on_any_request_error(self):

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -356,7 +356,7 @@ class TestInfobloxConnector(unittest.TestCase):
                          url)
 
     def test_get_object_with_proxy_flag(self):
-        self.connector._get_object = mock.MagicMock(return_value=False)
+        self.connector._get_object = mock.MagicMock(return_value=None)
         self.connector._construct_url = mock.MagicMock()
         self.connector.cloud_api_enabled = True
 
@@ -371,7 +371,9 @@ class TestInfobloxConnector(unittest.TestCase):
                                                self.connector._construct_url)
 
     def test_get_object_without_proxy_flag(self):
-        self.connector._get_object = mock.MagicMock(return_value=False)
+        self.connector._get_object = mock.MagicMock(
+            side_effect=[requests.HTTPError(), None],
+        )
         self.connector._construct_url = mock.MagicMock()
         self.connector.cloud_api_enabled = True
 
@@ -382,15 +384,17 @@ class TestInfobloxConnector(unittest.TestCase):
                            mock.call('network', {}, None, force_proxy=True)]
         self.connector._construct_url.assert_has_calls(construct_calls)
 
-    def test__get_object_search_error_return_none(self):
-        response = mock.Mock()
-        response.status_code = '404'
-        response.content = 'Object not found'
+    def test__get_object_raises_search_error(self):
+        url = 'http://some-url/'
+        response = requests.Response()
+        response.status_code = 404
+        response._content = 'Object not found'
+        response.url = url
         self.connector.session = mock.Mock()
         self.connector.session.get.return_value = response
 
-        url = 'http://some-url/'
-        self.assertEqual(None, self.connector._get_object('network', url))
+        with self.assertRaises(requests.HTTPError):
+            self.connector._get_object('network', url)
 
     def test_get_object_with_pagination_with_no_result(self):
         self.connector._get_object = mock.MagicMock(return_value=None)
@@ -600,6 +604,11 @@ class TestInfobloxConnector(unittest.TestCase):
             patched_get.return_value.content = '{}'
             self.connector.get_object(objtype, {})
             self.assertEqual(None, self.connector.session.auth)
+
+    # def test__get_object_raises_not_found(self):
+    #     self.connector.session.get = mock.MagicMock(
+    #         return_value=requests.request('GET', )
+    #     )
 
 
 class TestInfobloxConnectorStaticMethods(unittest.TestCase):


### PR DESCRIPTION
# Issue/Feature description

* Client user was unable to distinguish 4xx from 5xx errors returned by the WAPI.

# How it was fixed/implemented

* If API returns 4xx or 5xx error, Connector's _get_object method will raise an exception.

* If _get_object is called by public get_object method, the last one will
  catch above exception and try to repeat the request with option
  "_proxy_search=GM".

* Closes #290.

# Tests

* `test__get_object_raises_search_error` -- checks if `_get_object` method will raise exception, when WAPI response mock will have `404` status code.

* `test_get_object_without_proxy_flag` -- updated test mock for `_get_object` method to raise `HTTPError` instead of returning `None`.

# Reviewers

@anagha-infoblox