### PR TITLE
Renamed Dhcpoption class to DhcpOption to make it backwards compatible

### DIFF
--- a/infoblox_client/objects.py
+++ b/infoblox_client/objects.py
@@ -655,7 +655,7 @@ class Dhcpmember(SubObjects):
     _fields = ['_struct', 'ipv4addr', 'ipv6addr', 'name']
 
 
-class Dhcpoption(SubObjects):
+class DhcpOption(SubObjects):
     _fields = ['name', 'num', 'use_option', 'value', 'vendor_class']
 
 


### PR DESCRIPTION
# Issue/Feature description

* In the previous versions of the client the class was named "DhcpOption".

* In the version `v0.5.0` the class was renamed probably due to the `objects.py` auto-generation.

# How it was fixed/implemented

* Returned the old class name to make the library backwards compatible.

# Tests

* No tests.

# Reviewers

@sarya-infoblox 