### PR TITLE
Allow use_for_ea_inheritance field in IP objects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -152,6 +152,14 @@ Create host record with Extensible Attributes (EA):
                    'Cloud API Owned': True})
   host = objects.HostRecord.create(conn, name='new_host', ip=my_ip, extattrs=ea)
 
+Create a host record with inherited Extensible Attributes (EA):
+
+.. code:: python
+
+  my_ip = objects.IP.create(ip='192.168.1.25', mac='aa:bb:cc:11:22:33', use_for_ea_inheritance=True)
+  hr = objects.HostRecord.create(conn, view='my_dns_view',
+                                 name='my_host_record.my_zone.com', ip=my_ip)
+
 Set the TTL to 30 minutes:
 
 .. code:: python

--- a/infoblox_client/objects.py
+++ b/infoblox_client/objects.py
@@ -558,13 +558,15 @@ class IP(SubObjects):
 
 
 class IPv4(IP):
-    _fields = ['ipv4addr', 'configure_for_dhcp', 'use_for_ea_inheritance', 'mac']
+    _fields = ['ipv4addr', 'configure_for_dhcp',
+               'use_for_ea_inheritance', 'mac']
     _remap = {'ipv4addr': 'ip'}
     ip_version = 4
 
 
 class IPv6(IP):
-    _fields = ['ipv6addr', 'configure_for_dhcp', 'use_for_ea_inheritance', 'duid']
+    _fields = ['ipv6addr', 'configure_for_dhcp',
+               'use_for_ea_inheritance', 'duid']
     _remap = {'ipv6addr': 'ip'}
     ip_version = 6
 

--- a/infoblox_client/objects.py
+++ b/infoblox_client/objects.py
@@ -546,13 +546,13 @@ class IP(SubObjects):
 
 
 class IPv4(IP):
-    _fields = ['ipv4addr', 'configure_for_dhcp', 'mac']
+    _fields = ['ipv4addr', 'configure_for_dhcp', 'use_for_ea_inheritance', 'mac']
     _remap = {'ipv4addr': 'ip'}
     ip_version = 4
 
 
 class IPv6(IP):
-    _fields = ['ipv6addr', 'configure_for_dhcp', 'duid']
+    _fields = ['ipv6addr', 'configure_for_dhcp', 'use_for_ea_inheritance', 'duid']
     _remap = {'ipv6addr': 'ip'}
     ip_version = 6
 


### PR DESCRIPTION
# Issue/Feature description

* This allows EAs to be inherited from the parent object instead of
being overridden when calling objects.HostRecord.create()

# How it was fixed/implemented

* allow use_for_ea_inheritance field in IP objects

# Tests

* Tested with WAPI version 2.11.3
