### PR TITLE
Created GH actions pipeline for unit-testing/linting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,20 @@ on:
       - 'README.md'
       - 'docs/**'
 jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+        - uses: actions/checkout@v3
+        - name: Set up Python 3.6
+          uses: actions/setup-python@v3
+          with:
+            python-version: '3.6'
+        - name: Lint with tox
+          run: tox
+          env:
+            TOXENV: pep8
   test:
     name: Unit Test
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,41 +12,39 @@ on:
       - 'docs/**'
 jobs:
   test:
-      name: Unit Test
-      runs-on: ubuntu-latest
-      timeout-minutes: 15
-      strategy:
-          fail-fast: false
-          matrix:
-              # A list of Python versions to run the tests on
-              python-version: ['2.7', '3.5', '3.6', '3.7', '3.8', '3.9']
-              include:
-                - python-version: '2.7'
-                  TOXENV: 'py27'
-                - python-version: '3.5'
-                  TOXENV: 'py35'
-                - python-version: '3.6'
-                  TOXENV: 'py36'
-                - python-version: '3.7'
-                  TOXENV: 'py37'
-                - python-version: '3.8'
-                  TOXENV: 'py38'
-                - python-version: '3.9'
-                  TOXENV: 'py39'
-                - python-version: '3.6'
-                  TOXENV: 'pep8'
-      steps:
-        - uses: actions/checkout@v3
-        - name: Set up Python ${{ matrix.python-version }}
-          uses: actions/setup-python@v3
-          with:
-            python-version: ${{ matrix.python-version }}
-        - name: Install dependencies
-          run: |
-            python -m pip install --upgrade pip
-            pip install -r requirements.txt
-            pip install -r testing_requirements.txt
-        - name: Test with tox
-          run: tox
-          env:
-            TOXENV: ${{ matrix.TOXENV }}
+    name: Unit Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        # A list of Python versions to run the tests on
+        python-version: ['2.7', '3.5', '3.6', '3.7', '3.8', '3.9']
+        include:
+          - python-version: '2.7'
+            TOXENV: 'py27'
+          - python-version: '3.5'
+            TOXENV: 'py35'
+          - python-version: '3.6'
+            TOXENV: 'py36'
+          - python-version: '3.7'
+            TOXENV: 'py37'
+          - python-version: '3.8'
+            TOXENV: 'py38'
+          - python-version: '3.9'
+            TOXENV: 'py39'
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -r testing_requirements.txt
+      - name: Test with tox
+        run: tox
+        env:
+          TOXENV: ${{ matrix.TOXENV }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,51 @@
+# This GitHub action runs your tests for each commit push and/or PR. Optionally
+# you can turn it on using a cron schedule for regular testing.
+name: Unit Tests
+on:
+  pull_request:
+    paths-ignore:
+      - 'README.md'
+      - 'docs/**'
+  push:
+    paths-ignore:
+      - 'README.md'
+      - 'docs/**'
+jobs:
+  test:
+      name: Unit Test
+      runs-on: ubuntu-latest
+      timeout-minutes: 15
+      strategy:
+          fail-fast: false
+          matrix:
+              # A list of Python versions to run the tests on
+              python-version: ['2.7', '3.5', '3.6', '3.7', '3.8', '3.9']
+              include:
+                - python-version: '2.7'
+                  TOXENV: 'py27'
+                - python-version: '3.5'
+                  TOXENV: 'py35'
+                - python-version: '3.6'
+                  TOXENV: 'py36'
+                - python-version: '3.7'
+                  TOXENV: 'py37'
+                - python-version: '3.8'
+                  TOXENV: 'py38'
+                - python-version: '3.9'
+                  TOXENV: 'py39'
+                - python-version: '3.6'
+                  TOXENV: 'pep8'
+      steps:
+        - uses: actions/checkout@v3
+        - name: Set up Python ${{ matrix.python-version }}
+          uses: actions/setup-python@v3
+          with:
+            python-version: ${{ matrix.python-version }}
+        - name: Install dependencies
+          run: |
+            python -m pip install --upgrade pip
+            pip install -r requirements.txt
+            pip install -r testing_requirements.txt
+        - run: export ${{ matrix.TOXENV }}
+        - name: Test with tox
+          run: tox

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,7 @@ jobs:
             python -m pip install --upgrade pip
             pip install -r requirements.txt
             pip install -r testing_requirements.txt
-        - run: export TOXENV=${{ matrix.TOXENV }}
         - name: Test with tox
           run: tox
+          env:
+            TOXENV: ${{ matrix.TOXENV }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,10 @@ jobs:
           uses: actions/setup-python@v3
           with:
             python-version: '3.6'
+        - name: Install dependencies
+          run: |
+            python -m pip install --upgrade pip
+            pip install tox
         - name: Lint with tox
           run: tox
           env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,6 @@ jobs:
             python -m pip install --upgrade pip
             pip install -r requirements.txt
             pip install -r testing_requirements.txt
-        - run: export ${{ matrix.TOXENV }}
+        - run: export TOXENV=${{ matrix.TOXENV }}
         - name: Test with tox
           run: tox

--- a/infoblox_client/objects.py
+++ b/infoblox_client/objects.py
@@ -346,7 +346,7 @@ class InfobloxObject(BaseObject):
     @classmethod
     def _search(cls, connector, return_fields=None,
                 search_extattrs=None, force_proxy=False,
-                max_results=None,paging=False, **kwargs):
+                max_results=None, paging=False, **kwargs):
         ib_obj_for_search = cls(connector, **kwargs)
         search_dict = ib_obj_for_search.to_dict(search_fields='all')
         if return_fields is None and ib_obj_for_search.return_fields:

--- a/infoblox_client/utils.py
+++ b/infoblox_client/utils.py
@@ -122,7 +122,8 @@ def paging(response, max_results):
 
     Args:
         response (list): WAPI response.
-        max_results (int): Maximum number of objects to be returned in one page.
+        max_results (int): Maximum number of objects to be returned
+                           in one page.
     Returns:
         Generator object with WAPI response split page by page.
     """
@@ -130,4 +131,3 @@ def paging(response, max_results):
     while i < len(response):
         yield response[i:i + max_results]
         i = i + max_results
-

--- a/tests/test_object_manager.py
+++ b/tests/test_object_manager.py
@@ -169,7 +169,7 @@ class ObjectManagerTestCase(unittest.TestCase):
                                   PayloadMatcher.ANYKEY: ip_address})
         connector.get_object.assert_called_once_with(
             'record:host', matcher, extattrs=None, max_results=None,
-            force_proxy=mock.ANY, return_fields=mock.ANY)
+            force_proxy=mock.ANY, return_fields=mock.ANY, paging=False)
         connector.delete_object.assert_called_once_with(mock.ANY)
 
     def test_get_network_gets_network_object(self):
@@ -187,7 +187,7 @@ class ObjectManagerTestCase(unittest.TestCase):
                                   'network': cidr})
         connector.get_object.assert_called_once_with(
             'network', matcher, extattrs=None, max_results=None,
-            force_proxy=mock.ANY, return_fields=mock.ANY)
+            force_proxy=mock.ANY, return_fields=mock.ANY, paging=False)
 
     def test_object_is_not_created_if_already_exists(self):
         net_view_name = 'test_dns_view_name'
@@ -311,7 +311,7 @@ class ObjectManagerTestCase(unittest.TestCase):
                                   'network_view': net_view})
         connector.get_object.assert_called_once_with(
             'range', matcher, extattrs=None, max_results=None,
-            force_proxy=mock.ANY, return_fields=mock.ANY)
+            force_proxy=mock.ANY, return_fields=mock.ANY, paging=False)
         connector.delete_object.assert_called_once_with(mock.ANY)
 
     def test_delete_network_deletes_infoblox_network(self):
@@ -329,7 +329,7 @@ class ObjectManagerTestCase(unittest.TestCase):
                                   'network': cidr})
         connector.get_object.assert_called_once_with(
             'network', matcher, extattrs=None, max_results=None,
-            force_proxy=mock.ANY, return_fields=mock.ANY)
+            force_proxy=mock.ANY, return_fields=mock.ANY, paging=False)
         connector.delete_object.assert_called_once_with(mock.ANY)
 
     def test_delete_network_view_deletes_infoblox_object(self):
@@ -345,7 +345,7 @@ class ObjectManagerTestCase(unittest.TestCase):
         matcher = PayloadMatcher({'name': net_view})
         connector.get_object.assert_called_once_with(
             'networkview', matcher, extattrs=None, max_results=None,
-            force_proxy=mock.ANY, return_fields=mock.ANY)
+            force_proxy=mock.ANY, return_fields=mock.ANY, paging=False)
         connector.delete_object.assert_called_once_with(mock.ANY)
 
     def test_find_hostname(self):
@@ -365,7 +365,7 @@ class ObjectManagerTestCase(unittest.TestCase):
             {'view': dns_view_name, 'name': fqdn, 'ipv4addr': ip,
              'network_view': network_view_name},
             extattrs=None, force_proxy=mock.ANY, return_fields=mock.ANY,
-            max_results=None)
+            max_results=None, paging=False)
 
     def test_find_host_records_by_mac(self):
         dns_view_name = 'dns-view-name'
@@ -384,18 +384,18 @@ class ObjectManagerTestCase(unittest.TestCase):
                       {'view': dns_view_name, 'mac': mac,
                        'network_view': network_view_name},
                       extattrs=None, force_proxy=mock.ANY,
-                      return_fields=mock.ANY, max_results=None),
+                      return_fields=mock.ANY, max_results=None, paging=False),
             mock.call('record:host_ipv6addr',
                       {'network_view': 'network-view-name',
                        'duid': '11:22:33:44:55:66'},
                       extattrs=None, force_proxy=mock.ANY,
-                      return_fields=mock.ANY, max_results=None),
+                      return_fields=mock.ANY, max_results=None, paging=False),
             mock.call('record:host',
                       {'name': 'test_host_name',
                        'network_view': 'network-view-name',
                        'view': 'dns-view-name'},
                       extattrs=None, force_proxy=mock.ANY,
-                      return_fields=mock.ANY, max_results=None)]
+                      return_fields=mock.ANY, max_results=None, paging=False)]
 
     def _check_bind_names_calls(self, args, expected_get, expected_update):
         connector = mock.Mock()
@@ -407,7 +407,7 @@ class ObjectManagerTestCase(unittest.TestCase):
         connector.get_object.assert_called_once_with(
             'record:host', expected_get,
             extattrs=None, max_results=None,
-            force_proxy=mock.ANY, return_fields=mock.ANY)
+            force_proxy=mock.ANY, return_fields=mock.ANY, paging=False)
         connector.update_object.assert_called_once_with(
             mock.ANY, expected_update, mock.ANY)
 
@@ -465,8 +465,8 @@ class ObjectManagerTestCase(unittest.TestCase):
         ip = '192.168.1.1'
         bind_list = ['record:a', 'record:aaaa', 'record:ptr']
 
-        def get_object(obj_type, payload=None, return_fields=None,
-                       extattrs=None, force_proxy=False, max_results=None):
+        def get_object(obj_type, payload=None, return_fields=None, extattrs=None,
+                       force_proxy=False, paging=False, max_results=None):
             data_dict = payload.copy()
             data_dict['_ref'] = 'some-ref/' + obj_type
             return [data_dict]
@@ -519,7 +519,7 @@ class ObjectManagerTestCase(unittest.TestCase):
         matcher = PayloadMatcher({'network_view': net_view_name})
         connector.get_object.assert_called_once_with(
             'network', matcher, return_fields=mock.ANY, max_results=None,
-            force_proxy=mock.ANY, extattrs=None)
+            force_proxy=mock.ANY, extattrs=None, paging=False)
         self.assertEqual(False, result)
 
     def test_create_fixed_address_for_given_ip(self):
@@ -609,7 +609,7 @@ class ObjectManagerTestCase(unittest.TestCase):
                    'ipv4addr': ip}
         connector.get_object.assert_called_once_with(
             'fixedaddress', payload, extattrs=None, max_results=None,
-            return_fields=mock.ANY, force_proxy=mock.ANY)
+            return_fields=mock.ANY, force_proxy=mock.ANY, paging=False)
         connector.delete_object.assert_called_once_with(mock.ANY)
 
     def test_delete_fixed_address_not_found(self):
@@ -626,7 +626,7 @@ class ObjectManagerTestCase(unittest.TestCase):
                    'ipv4addr': ip}
         connector.get_object.assert_called_once_with(
             'fixedaddress', payload, extattrs=None, max_results=None,
-            return_fields=mock.ANY, force_proxy=mock.ANY)
+            return_fields=mock.ANY, force_proxy=mock.ANY, paging=False)
         self.assertFalse(connector.delete_object.called)
 
     @mock.patch('infoblox_client.objects.FixedAddress')
@@ -767,7 +767,7 @@ class ObjectManagerTestCase(unittest.TestCase):
             'zone_auth',
             {'fqdn': 'host.global.com', 'view': 'dns-view-name'},
             return_fields=return_fields,
-            extattrs=None, force_proxy=False, max_results=None)
+            extattrs=None, force_proxy=False, max_results=None, paging=False)
         connector.update_object.assert_called_once_with(
             zone_ref,
             {'extattrs': new_attrs,'ns_group': 'test_group',
@@ -838,7 +838,8 @@ class ObjectManagerTestCase(unittest.TestCase):
                                                      extattrs=None,
                                                      force_proxy=mock.ANY,
                                                      return_fields=mock.ANY,
-                                                     max_results=None)
+                                                     max_results=None,
+                                                     paging=False)
 
     def test_create_ea_definition(self):
         connector = mock.Mock()


### PR DESCRIPTION
# Issue/Feature description

* Some `infoblox-client` unit tests were broken by previous changes.

* Related to PR #307.

* We need a CI unit testing pipeline to check if some change brakes the `infoblox-cleint` logic.

# How it was fixed/implemented

* Created Github actions piplines for testing/linting.

* Fixed a couple of mintor tests related to `get_object`'s `paging` parameter in `test_objects.py` module.

# Tests

* `test_object_manager/test_delete_host_record_deletes_host_record_object` -- fixed mock assertion.
* `test_object_manager/test_get_network_gets_network_object` -- fixed mock assertion.
* `test_object_manager/test_delete_ip_range_deletes_infoblox_object` -- fixed mock assertion.
* `test_object_manager/test_delete_network_deletes_infoblox_network` -- fixed mock assertion.
* `test_object_manager/test_delete_network_view_deletes_infoblox_object` -- fixed mock assertion.
* `test_object_manager/test_find_hostname` -- fixed mock assertion.
* `test_object_manager/test_find_host_records_by_mac` -- fixed mock assertion.
* `test_object_manager/test_unbind_names_with_a_record` -- fixed mock assertion.
* `test_object_manager/test_has_networks` -- fixed mock assertion.
* `test_object_manager/test_delete_fixed_address` -- fixed mock assertion.
* `test_object_manager/test_delete_fixed_address_not_found` -- fixed mock assertion.
* `test_object_manager/test_update_dns_zone_attrs` -- fixed mock assertion.
* `test_object_manager/test_get_all_ea_defintions` -- fixed mock assertion.

# Reviewers

@sarya-infoblox 