### PR TITLE
Changes as per bug/NIOS_84322

### DIFF
--- a/infoblox_client/objects.py
+++ b/infoblox_client/objects.py
@@ -12839,7 +12839,8 @@ class AAAARecord(ARecordBase):
                'remove_associated_ptr', 'shared_record_group', 'ttl',
                'use_ttl', 'view', 'zone']
     _search_for_update_fields = ['ipv6addr', 'name', 'view']
-    _updateable_search_fields = ['comment', 'creator', 'ddns_principal']
+    _updateable_search_fields = ['comment', 'creator', 'ddns_principal',
+                                 'ipv6addr', 'name']
     _all_searchable_fields = ['comment', 'creator', 'ddns_principal',
                               'ipv6addr', 'name', 'reclaimable', 'view',
                               'zone']

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -602,7 +602,7 @@ class TestObjects(unittest.TestCase):
             return_fields=[])
         connector.update_object.assert_called_once_with(
             aaaa_record[0]['_ref'],
-            {'comment': 'new_test_comment'},
+            {'comment': 'new_test_comment', 'ipv6addr': '2001:610:240:22::c100:68b'},
             mock.ANY)
 
     def test_ip_version(self):


### PR DESCRIPTION
# Issue/Feature description

* The update calls from the Infoblox-client plugin  for object 'record:aaaa' on fields ['name', 'ipv6addr'] are breaking as per bug NIOS-84322

# How it was fixed/implemented

* Added ['ipv6addr', 'name'] to DNSZone class update fields.
* Fixed Test cases to support the update call.

# Tests

* No Tests
