### PR TITLE
Bug/nios 84427

### DIFF
--- a/e2e_tests/test_objects.py
+++ b/e2e_tests/test_objects.py
@@ -81,3 +81,18 @@ class TestObjectsE2E(unittest.TestCase):
         zone2._ref = zone1._ref
         zone2.fetch()
         self.assertEqual(zone1.fqdn, zone2.fqdn)
+
+    def test_update_dns_zone(self):
+        """
+        Validates if DNS Zone object can be updated
+
+        Related ticket: NIOS-84427
+        """
+        # Create DNS Zone
+        zone = DNSZone.create(self.connector,
+                              fqdn="e2e-test-zone.com",
+                              view="default")
+        # Update DNS zone
+        zone.Comment = "Modified"
+        zone.update()
+

--- a/infoblox_client/objects.py
+++ b/infoblox_client/objects.py
@@ -18115,7 +18115,7 @@ class DNSZone(InfobloxObject):
     _all_searchable_fields = ['comment', 'dnssec_ksk_rollover_date',
                               'dnssec_zsk_rollover_date', 'fqdn', 'parent',
                               'view', 'zone_format']
-    _return_fields = ['extattrs', 'fqdn', 'view', 'zone_format', 'ns_group',
+    _return_fields = ['extattrs', 'fqdn', 'view', 'ns_group',
                       'prefix', 'grid_primary', 'grid_secondaries']
     _remap = {}
     _shadow_fields = ['_ref']

--- a/tests/test_object_manager.py
+++ b/tests/test_object_manager.py
@@ -759,7 +759,7 @@ class ObjectManagerTestCase(unittest.TestCase):
         connector.get_object.return_value = [zone]
 
         return_fields = [
-            'extattrs', 'fqdn', 'view', 'zone_format', 'ns_group', 'prefix',
+            'extattrs', 'fqdn', 'view', 'ns_group', 'prefix',
             'grid_primary', 'grid_secondaries']
         ibom = om.InfobloxObjectManager(connector)
         ibom.update_dns_zone_attrs(dns_view_name, fqdn, new_attrs)


### PR DESCRIPTION
# Issue/Feature description

* Exception raised while updating DNSZone record

# How it was fixed/implemented

* The field 'zone_format' was added manually to '_return_fields' of 'class DNSZone' in the objects.py module. Due to this an extra field 'zone_format' ( field is not allowed to update) is coming up while updating the object 'DNSZone' 

