### PR TITLE
Changes as per bug/NIOS-84387

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -757,6 +757,9 @@ defined as ``place_to_check`` in the code below.
         }
       ]
     }
+Known issues
+------------
+1. When the record is created successfully, the response parameter will raise 'AttributeError' to the call 'record.response'. 
 
 Features
 --------


### PR DESCRIPTION
# Issue/Feature description

* Missing response parameter when DNSZone record created successfully.

# How it was fixed/implemented

* The response parameter was getting missed at the internal function call to 'from_dict'. Passing the response parameter separately would solve the problem but it will break the backward compatibility of the code. Hence adding it to 'Known Issues' in README.rst.

