### PR TITLE
Bug NIOS-84387: Fixed response field return logic for the InfobloxObject.create method

### DIFF
--- a/e2e_tests/connector_facade.py
+++ b/e2e_tests/connector_facade.py
@@ -22,6 +22,14 @@ class E2EConnectorFacade(Connector):
         self.__delete_queue.append(resp['_ref'])
         return resp
 
+    def update_object(self, ref, payload, return_fields=None):
+        new_obj = super(E2EConnectorFacade, self).update_object(ref,
+                                                                payload,
+                                                                return_fields)
+        self.__delete_queue.remove(ref)
+        self.__delete_queue.append(new_obj["_ref"])
+        return new_obj
+
     def delete_object(self, ref, delete_arguments=None):
         self.__delete_queue.remove(ref)
         return super(E2EConnectorFacade, self).delete_object(ref,

--- a/e2e_tests/test_objects.py
+++ b/e2e_tests/test_objects.py
@@ -66,6 +66,19 @@ class TestObjectsE2E(unittest.TestCase):
         self.assertTrue(created)
         self.assertNotEqual(alias1._ref, alias2._ref)
 
+    def test_create_object_check_response(self):
+        """Objects returned by create method should contain response field"""
+        # When WAPI object is successfully created
+        zone = DNSZone.create(self.connector, view='default', fqdn='check_response_zone.com')
+        self.assertEqual("Infoblox Object was Created", zone.response)
+        # When WAPI object already exists
+        zone = DNSZone.create(self.connector, view='default', fqdn='check_response_zone.com')
+        self.assertEqual("Infoblox Object already Exists", zone.response)
+        # When WAPI object is updated
+        zone = DNSZone.create(self.connector, view='default', fqdn='check_response_zone.com',
+                              comment="Zone updated", update_if_exists=True, ref=zone.ref)
+        self.assertEqual("Infoblox Object was Updated", zone.response)
+
     def test_fetch_by_ref_when_paging_enabled(self):
         """
         Fetch should explicitly disable paging, when reading object from

--- a/infoblox_client/objects.py
+++ b/infoblox_client/objects.py
@@ -305,6 +305,8 @@ class InfobloxObject(BaseObject):
         # and getting created with this function call
         obj_created = False
         local_obj = cls(connector, **kwargs)
+        response = None
+
         if check_if_exists:
             if local_obj.fetch(only_ref=True):
                 LOG.info(("Infoblox %(obj_type)s already exists: "
@@ -323,19 +325,36 @@ class InfobloxObject(BaseObject):
             LOG.info("Infoblox %(obj_type)s was created: %(ib_obj)s",
                      {'obj_type': local_obj.infoblox_type,
                       'ib_obj': local_obj})
-            local_obj.response = "Infoblox Object was Created"
+            response = "Infoblox Object was Created"
         elif update_if_exists:
             update_fields = local_obj.to_dict(search_fields='exclude')
             reply = connector.update_object(local_obj.ref,
                                             update_fields,
                                             local_obj.return_fields)
             LOG.info('Infoblox object was updated: %s', local_obj.ref)
-            local_obj.response = "Infoblox Object was Updated"
-        return cls._object_from_reply(local_obj, connector, reply), obj_created
+            response = "Infoblox Object was Updated"
+
+        obj_result = cls._object_from_reply(local_obj, connector, reply)
+        obj_result.response = response
+        return obj_result, obj_created
 
     @classmethod
     def create(cls, connector, check_if_exists=True,
                update_if_exists=False, **kwargs):
+        """Create the object in NIOS.
+
+        Args:
+            check_if_exists: If True, create method will attempt
+                to fetch the object to check if it exists.
+            update_if_exists: If True, create method will attempt
+                to update the object if one exists.
+
+        Raises:
+            InfobloxFetchGotMultipleObjects: Raised only when check_if_exists is True.
+                The fetch method can raise this error when API return multiple objects.
+
+        Returns: Created Infoblox object.
+        """
         ib_object, _ = (
             cls.create_check_exists(connector,
                                     check_if_exists=check_if_exists,

--- a/infoblox_client/objects.py
+++ b/infoblox_client/objects.py
@@ -335,7 +335,12 @@ class InfobloxObject(BaseObject):
             response = "Infoblox Object was Updated"
 
         obj_result = cls._object_from_reply(local_obj, connector, reply)
-        obj_result.response = response
+
+        # Add response string if object is not None
+        # and properly deserialized
+        if issubclass(type(obj_result), BaseObject):
+            obj_result.response = response
+
         return obj_result, obj_created
 
     @classmethod

--- a/infoblox_client/objects.py
+++ b/infoblox_client/objects.py
@@ -350,8 +350,9 @@ class InfobloxObject(BaseObject):
                 to update the object if one exists.
 
         Raises:
-            InfobloxFetchGotMultipleObjects: Raised only when check_if_exists is True.
-                The fetch method can raise this error when API return multiple objects.
+            InfobloxFetchGotMultipleObjects: Raised only when check_if_exists
+                is True. The fetch method can raise this error when API return
+                multiple objects.
 
         Returns: Created Infoblox object.
         """


### PR DESCRIPTION
# Issue/Feature description

* Previously, `create` method returned `response` as an object field only when object already exists. For other cases `response` field wasn't returned, because it was dropped by [to_dict method](https://github.com/infobloxopen/infoblox-client/blob/v0.5.0/infoblox_client/objects.py#L268-L283), which deserializes API response into a python class instance.

# How it was fixed/implemented

* Now `create_check_exists` method will return WAPI `response` as a field of returned object for each case (e.g. create a new object, update existing object, just find existing object), because this `response` field is added after object deserialization.

* Also added docstring for the `create` method.

# Tests

*  Added update_object method for the e2e connector_facade.py. Now, when e2e connector facade is used to update some object, facade will remove the old object ref from delete queue and add a new one to the same queue.

* Created e2e test to check if create method return a response. Create method should return a response message as a returned object's field, when new object is created, when object already exists, and when existing object is updated.