### PR TITLE
[NIOS-84390] Client should throw error, when serching with non-searchable fields

### DIFF
--- a/infoblox_client/exceptions.py
+++ b/infoblox_client/exceptions.py
@@ -130,3 +130,7 @@ class InfobloxGridTemporaryUnavailable(InfobloxException):
 class InfobloxFetchGotMultipleObjects(BaseExc):
     message = "Fetch got multiple objects from the API. Unable to " \
               "deserialize multiple API objects into one InfobloxObject."
+
+
+class InfobloxFieldNotSearchable(BaseExc):
+    message = "Field is not searchable: %(field)s"

--- a/infoblox_client/exceptions.py
+++ b/infoblox_client/exceptions.py
@@ -133,4 +133,4 @@ class InfobloxFetchGotMultipleObjects(BaseExc):
 
 
 class InfobloxFieldNotSearchable(BaseExc):
-    message = "Field is not searchable: %(fields)s"
+    message = "Field is not searchable: %(field)s"

--- a/infoblox_client/objects.py
+++ b/infoblox_client/objects.py
@@ -275,6 +275,8 @@ class InfobloxObject(BaseObject):
             fields = self._search_for_update_fields
         elif search_fields == 'all':
             fields = self._all_searchable_fields
+        elif search_fields == 'search':
+            fields = self._fields
         elif search_fields == 'exclude':
             # exclude search fields for update actions,
             # but include updateable_search_fields
@@ -356,6 +358,11 @@ class InfobloxObject(BaseObject):
         extattrs = search_extattrs
         if hasattr(search_extattrs, 'to_dict'):
             extattrs = search_extattrs.to_dict()
+        search_fields = ib_obj_for_search.to_dict(search_fields='search')
+        for key in search_fields:
+            if key not in search_dict:
+                raise ib_ex.InfobloxFieldNotSearchable(
+                    field=search_fields.keys())
         reply = connector.get_object(ib_obj_for_search.infoblox_type,
                                      search_dict,
                                      return_fields=return_fields,

--- a/infoblox_client/objects.py
+++ b/infoblox_client/objects.py
@@ -362,7 +362,7 @@ class InfobloxObject(BaseObject):
         for key in search_fields:
             if key not in search_dict:
                 raise ib_ex.InfobloxFieldNotSearchable(
-                    field=search_fields.keys())
+                    field=key)
         reply = connector.get_object(ib_obj_for_search.infoblox_type,
                                      search_dict,
                                      return_fields=return_fields,

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -684,7 +684,7 @@ class TestObjects(unittest.TestCase):
             re.match(
                 # For Python 3.x and 2.x string repr of dict keys may differ.
                 # This regex matches both representations.
-                r"^Field is not searchable: (dict_keys)?(\()?\['use_ttl'\](\))?$",
+                r"^Field is not searchable: use_ttl",
                 str(e.exception),
             ),
             "Exception string '%s' doesn't match test regexp" % e.exception


### PR DESCRIPTION
# Issue/Feature description

* Invalid result while searching with Non-searchable fields

# How it was fixed/implemented

* Added functionality to check if the field is present in searchable fields else will raise an exception.

