### PR TITLE
Bug/nios 84402

### DIFF
--- a/infoblox_client/exceptions.py
+++ b/infoblox_client/exceptions.py
@@ -130,3 +130,7 @@ class InfobloxGridTemporaryUnavailable(InfobloxException):
 class InfobloxFetchGotMultipleObjects(BaseExc):
     message = "Fetch got multiple objects from the API. Unable to " \
               "deserialize multiple API objects into one InfobloxObject."
+
+
+class InfobloxFieldNotSearchable(BaseExc):
+    message = "Field is not searchable: %(field)s"

--- a/infoblox_client/exceptions.py
+++ b/infoblox_client/exceptions.py
@@ -134,3 +134,7 @@ class InfobloxFetchGotMultipleObjects(BaseExc):
 
 class InfobloxFieldNotSearchable(BaseExc):
     message = "Field is not searchable: %(field)s"
+
+
+class InfobloxMissingFields(BaseExc):
+    message = "Infoblox object can not be created. Required fields: %(field)s"

--- a/infoblox_client/object_manager.py
+++ b/infoblox_client/object_manager.py
@@ -370,7 +370,7 @@ class InfobloxObjectManager(object):
             host_record.update()
 
     def bind_name_with_record_a(self, dns_view, ip, name, bind_list,
-                                extattrs):
+                                 extattrs):
         is_ipv4 = ib_utils.determine_ip_version(ip) == 4
         if ((is_ipv4 and 'record:a' in bind_list) or
                 (not is_ipv4 and 'record:aaaa' in bind_list)):

--- a/infoblox_client/objects.py
+++ b/infoblox_client/objects.py
@@ -190,6 +190,7 @@ class InfobloxObject(BaseObject):
         _shadow_fields: fields that object usually has but they should not
             be sent to NIOS. These fields can be received from
             NIOS. Examples: [_ref, is_default]
+        _required_fields: fields that are required to create an NIOS object.
         _return_fields: fields requested to be returned from NIOS side
             if object is found/created
         _infoblox_type: string representing wapi type of described object
@@ -213,6 +214,7 @@ class InfobloxObject(BaseObject):
     _all_searchable_fields = []
     _updateable_search_fields = []
     _shadow_fields = []
+    _required_fields = []
     _infoblox_type = None
     _remap = {}
 
@@ -345,6 +347,12 @@ class InfobloxObject(BaseObject):
 
         return obj_result, obj_created
 
+    def r_fields(self, ib_objects):
+        if not set(self._required_fields).issubset(set(ib_objects.keys())):
+            LOG.debug("Infoblox object can not be created. Required fields "
+                      "%(field)s", self._required_fields)
+            raise ib_ex.InfobloxMissingFields(field=str(self._required_fields))
+
     @classmethod
     def create(cls, connector, check_if_exists=True,
                update_if_exists=False, **kwargs):
@@ -363,6 +371,8 @@ class InfobloxObject(BaseObject):
 
         Returns: Created Infoblox object.
         """
+        local_obj = cls(connector, **kwargs)
+        local_obj.r_fields(dict(**kwargs))
         ib_object, _ = (
             cls.create_check_exists(connector,
                                     check_if_exists=check_if_exists,
@@ -12793,6 +12803,7 @@ class ARecord(ARecordBase):
     _return_fields = ['extattrs', 'ipv4addr', 'name', 'view']
     _remap = {'ip': 'ipv4addr'}
     _shadow_fields = ['_ref', 'ip']
+    _required_fields = ['ipv4addr', 'name']
     _ip_version = 4
 
     @property
@@ -12879,6 +12890,7 @@ class AAAARecord(ARecordBase):
     _return_fields = ['extattrs', 'ipv6addr', 'name', 'view']
     _remap = {'ip': 'ipv6addr'}
     _shadow_fields = ['_ref', 'ip']
+    _required_fields = ['ipv6addr', 'name']
     _ip_version = 6
 
     @property
@@ -13080,6 +13092,7 @@ class CNAMERecord(InfobloxObject):
     _return_fields = ['canonical', 'extattrs', 'name', 'view']
     _remap = {}
     _shadow_fields = ['_ref']
+    _required_fields = ['canonical', 'name']
 
 
 class DhcidRecord(InfobloxObject):
@@ -13909,6 +13922,7 @@ class MXRecord(InfobloxObject):
                       'view']
     _remap = {}
     _shadow_fields = ['_ref']
+    _required_fields = ['mail_exchanger', 'name', 'preference']
 
 
 class NaptrRecord(InfobloxObject):
@@ -14335,6 +14349,7 @@ class PtrRecordV4(PtrRecord):
     _return_fields = ['extattrs', 'ptrdname', 'view', 'ipv4addr']
     _remap = {'ip': 'ipv4addr'}
     _shadow_fields = ['_ref', 'ipv4addr']
+    _required_fields = ['ipv4addr', 'name', 'ptrdname']
     _ip_version = 4
 
 
@@ -14409,6 +14424,7 @@ class PtrRecordV6(PtrRecord):
     _return_fields = ['extattrs', 'ptrdname', 'view', 'ipv6addr']
     _remap = {'ip': 'ipv6addr'}
     _shadow_fields = ['_ref', 'ipv6addr']
+    _required_fields = ['ipv6addr', 'name', 'ptrdname']
     _ip_version = 6
 
 
@@ -15389,6 +15405,7 @@ class SRVRecord(InfobloxObject):
                       'weight']
     _remap = {}
     _shadow_fields = ['_ref']
+    _required_fields = ['name', 'port', 'priority', 'target', 'weight']
 
 
 class TlsaRecord(InfobloxObject):
@@ -15515,6 +15532,7 @@ class TXTRecord(InfobloxObject):
     _return_fields = ['extattrs', 'name', 'text', 'view']
     _remap = {}
     _shadow_fields = ['_ref']
+    _required_fields = ['name', 'text']
 
 
 class UnknownRecord(InfobloxObject):
@@ -17674,6 +17692,7 @@ class DNSView(InfobloxObject):
     _return_fields = ['comment', 'extattrs', 'is_default', 'name']
     _remap = {}
     _shadow_fields = ['_ref']
+    _required_fields = ['name']
 
     _custom_field_processing = {
         'custom_root_name_servers': Extserver.from_dict,
@@ -18151,6 +18170,7 @@ class DNSZone(InfobloxObject):
                       'prefix', 'grid_primary', 'grid_secondaries']
     _remap = {}
     _shadow_fields = ['_ref']
+    _required_fields = ['fqdn']
 
     _custom_field_processing = {
         'allow_active_dir': Addressac.from_dict,
@@ -18445,6 +18465,7 @@ class DNSZoneForward(InfobloxObject):
     _return_fields = ['extattrs', 'forward_to', 'fqdn', 'view']
     _remap = {}
     _shadow_fields = ['_ref']
+    _required_fields = ['forward_to', 'fqdn']
 
     _custom_field_processing = {
         'forward_to': Extserver.from_dict,
@@ -18771,6 +18792,7 @@ class ZoneStub(InfobloxObject):
     _return_fields = ['extattrs', 'fqdn', 'stub_from', 'view']
     _remap = {}
     _shadow_fields = ['_ref']
+    _required_fields = ['fqdn', 'stub_from']
 
     _custom_field_processing = {
         'stub_from': Extserver.from_dict,

--- a/infoblox_client/objects.py
+++ b/infoblox_client/objects.py
@@ -275,6 +275,8 @@ class InfobloxObject(BaseObject):
             fields = self._search_for_update_fields
         elif search_fields == 'all':
             fields = self._all_searchable_fields
+        elif search_fields == 'search':
+            fields = self._fields
         elif search_fields == 'exclude':
             # exclude search fields for update actions,
             # but include updateable_search_fields
@@ -356,6 +358,11 @@ class InfobloxObject(BaseObject):
         extattrs = search_extattrs
         if hasattr(search_extattrs, 'to_dict'):
             extattrs = search_extattrs.to_dict()
+        search_fields = ib_obj_for_search.to_dict(search_fields='search')
+        for key in search_fields:
+            if key not in search_dict:
+                raise ib_ex.InfobloxFieldNotSearchable(
+                    field=search_fields.keys())
         reply = connector.get_object(ib_obj_for_search.infoblox_type,
                                      search_dict,
                                      return_fields=return_fields,

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -501,7 +501,8 @@ class TestInfobloxConnector(unittest.TestCase):
             )
 
     def test_call_upload_file(self):
-        upload_file_path = '/http_direct_file_io/req_id-UPLOAD-0302163936014609/ibx_networks.csv'
+        upload_file_path = '/http_direct_file_io/' \
+                           'req_id-UPLOAD-0302163936014609/ibx_networks.csv'
         upload_url = 'https://infoblox.example.org' + upload_file_path
         self._create_infoblox_csv()
         with open('tests/ibx_networks.csv', 'r') as fh:
@@ -518,7 +519,8 @@ class TestInfobloxConnector(unittest.TestCase):
             self._delete_infoblox_csv()
 
     def test_call_upload_file_with_error_403(self):
-        upload_file_path = '/http_direct_file_io/req_id-UPLOAD-0302163936014609/ibx_networks.csv'
+        upload_file_path = '/http_direct_file_io/' \
+                           'req_id-UPLOAD-0302163936014609/ibx_networks.csv'
         upload_url = 'https://infoblox.example.org' + upload_file_path
         self._create_infoblox_csv()
         with open('tests/ibx_networks.csv', 'r') as fh:
@@ -536,7 +538,9 @@ class TestInfobloxConnector(unittest.TestCase):
             self._delete_infoblox_csv()
 
     def test_call_download_file(self):
-        download_file_path = '/http_direct_file_io/req_id-DOWNLOAD-0302163936014609/ibx_networks.csv'
+        download_file_path = '/http_direct_file_io/' \
+                             'req_id-DOWNLOAD-0302163936014609/' \
+                             'ibx_networks.csv'
         download_url = 'https://infoblox.example.org' + download_file_path
         with patch.object(requests.Session, 'get',
                           return_value=mock.Mock()) as patched_get:
@@ -547,7 +551,9 @@ class TestInfobloxConnector(unittest.TestCase):
             self.assertEqual(None, self.connector.session.auth)
 
     def test_call_download_file_with_error_403(self):
-        download_file_path = '/http_direct_file_io/req_id-DOWNLOAD-0302163936014609/ibx_networks.csv'
+        download_file_path = '/http_direct_file_io/' \
+                             'req_id-DOWNLOAD-0302163936014609/' \
+                             'ibx_networks.csv'
         download_url = 'https://infoblox.example.org' + download_file_path
         with patch.object(requests.Session, 'get',
                           return_value=mock.Mock()) as patched_get:

--- a/tests/test_object_manager.py
+++ b/tests/test_object_manager.py
@@ -465,8 +465,9 @@ class ObjectManagerTestCase(unittest.TestCase):
         ip = '192.168.1.1'
         bind_list = ['record:a', 'record:aaaa', 'record:ptr']
 
-        def get_object(obj_type, payload=None, return_fields=None, extattrs=None,
-                       force_proxy=False, paging=False, max_results=None):
+        def get_object(obj_type, payload=None, return_fields=None,
+                       extattrs=None, force_proxy=False,
+                       paging=False, max_results=None):
             data_dict = payload.copy()
             data_dict['_ref'] = 'some-ref/' + obj_type
             return [data_dict]
@@ -770,7 +771,7 @@ class ObjectManagerTestCase(unittest.TestCase):
             extattrs=None, force_proxy=False, max_results=None, paging=False)
         connector.update_object.assert_called_once_with(
             zone_ref,
-            {'extattrs': new_attrs,'ns_group': 'test_group',
+            {'extattrs': new_attrs, 'ns_group': 'test_group',
              'view': 'dns-view-name', 'zone_format': 'FORWARD'},
             return_fields)
 

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -123,10 +123,13 @@ class TestObjects(unittest.TestCase):
 
     def test_search_network_with_grid_dhcp_members(self):
         found = {
-            '_ref': 'network/ZG5zLm5ldHdvcmskMTAuMC4zMi4wLzI0LzA:10.0.32.0/24/default',
+            '_ref': 'network/ZG5zLm5ldHdvcmskMTAuMC4zMi4wLzI0LzA:10.0.32.0/'
+                    '24/default',
             'members': [
-                {'_struct': 'dhcpmember', 'ipv4addr': '192.168.10.67', 'name': 'dhcp01.example.com'},
-                {'_struct': 'dhcpmember', 'ipv4addr': '192.168.11.67', 'name': 'dhcp02.example.com'}
+                {'_struct': 'dhcpmember', 'ipv4addr': '192.168.10.67',
+                 'name': 'dhcp01.example.com'},
+                {'_struct': 'dhcpmember', 'ipv4addr': '192.168.11.67',
+                 'name': 'dhcp02.example.com'}
             ]
         }
         connector = self._mock_connector(get_object=[found])
@@ -152,10 +155,13 @@ class TestObjects(unittest.TestCase):
 
     def test_search_network_with_ms_dhcp_members(self):
         found = {
-            '_ref': 'network/ZG5zLm5ldHdvcmskMTAuMC4zMi4wLzI0LzA:10.0.32.0/24/default',
+            '_ref': 'network/ZG5zLm5ldHdvcmskMTAuMC4zMi4wLzI0LzA:10.0.32.0/'
+                    '24/default',
             'members': [
-                {'_struct': 'msdhcpserver', 'ipv4addr': '192.168.10.67', 'name': 'dhcp01.example.com'},
-                {'_struct': 'msdhcpserver', 'ipv4addr': '192.168.11.67', 'name': 'dhcp02.example.com'}
+                {'_struct': 'msdhcpserver', 'ipv4addr': '192.168.10.67',
+                 'name': 'dhcp01.example.com'},
+                {'_struct': 'msdhcpserver', 'ipv4addr': '192.168.11.67',
+                 'name': 'dhcp02.example.com'}
             ]
         }
         connector = self._mock_connector(get_object=[found])
@@ -221,8 +227,8 @@ class TestObjects(unittest.TestCase):
             {'mail_exchanger': 'demo.my_zone.com',
              'name': 'mx.demo.my_zone.com',
              'preference': 1,
-             'view': 'my_dns_view'
-            }, ['extattrs', 'mail_exchanger','name', 'preference', 'view'])
+             'view': 'my_dns_view'},
+            ['extattrs', 'mail_exchanger', 'name', 'preference', 'view'])
 
     def test_update_MX_Record(self):
         mx_record_copy = [
@@ -240,8 +246,8 @@ class TestObjects(unittest.TestCase):
         connector.update_object.assert_called_once_with(
             mx_record_copy[0]['_ref'],
             {'mail_exchanger': 'demo2.my_zone.com',
-              'name': 'mx1.demo.my_zone.com', 'preference': 1},
-             ['extattrs', 'mail_exchanger', 'name', 'preference', 'view'])
+             'name': 'mx1.demo.my_zone.com', 'preference': 1},
+            ['extattrs', 'mail_exchanger', 'name', 'preference', 'view'])
 
     def test_search_and_delete_MX_Record(self):
         mx_record_copy = copy.deepcopy(DEFAULT_MX_RECORD)
@@ -253,12 +259,12 @@ class TestObjects(unittest.TestCase):
         connector.get_object.assert_called_once_with(
             'record:mx', {'view': 'some_view',
                           'name': 'some_name'},
-            extattrs=None, force_proxy=False, max_results=None,paging=False,
-            return_fields=['extattrs', 'mail_exchanger', 'name', 'preference', 'view'])
+            extattrs=None, force_proxy=False, max_results=None, paging=False,
+            return_fields=['extattrs', 'mail_exchanger', 'name',
+                           'preference', 'view'])
         mx_record.delete()
         connector.delete_object.assert_called_once_with(
             DEFAULT_MX_RECORD['_ref'])
-
 
     def test_create_host_record_with_ttl(self):
         mock_record = DEFAULT_HOST_RECORD
@@ -403,12 +409,12 @@ class TestObjects(unittest.TestCase):
         connector.get_object.assert_called_once_with(
             'ipv6fixedaddress',
             {'duid': mock.ANY, 'ipv6addr': 'fffe:1234:1234::1',
-             'network_view': 'some-view' },
+             'network_view': 'some-view'},
             return_fields=mock.ANY)
         connector.create_object.assert_called_once_with(
             'ipv6fixedaddress',
             {'duid': mock.ANY, 'ipv6addr': 'fffe:1234:1234::1',
-             'network_view': 'some-view' }, mock.ANY)
+             'network_view': 'some-view'}, mock.ANY)
 
     @mock.patch('infoblox_client.utils.generate_duid')
     def test_fixed_address_v6(self, generate):
@@ -437,7 +443,8 @@ class TestObjects(unittest.TestCase):
         payload = {'network_view': 'some_view', 'ip_address': '192.168.1.5'}
         connector.get_object.assert_called_once_with(
             'ipv4address', payload, return_fields=mock.ANY,
-            paging=False, extattrs=None, force_proxy=mock.ANY, max_results=None)
+            paging=False, extattrs=None, force_proxy=mock.ANY,
+            max_results=None)
         self.assertIsInstance(ip, objects.IPv4Address)
         self.assertEqual(ip_mock[0]['objects'], ip.objects)
 
@@ -557,32 +564,33 @@ class TestObjects(unittest.TestCase):
 
         with self.assertRaises(ib_ex.InfobloxFetchGotMultipleObjects):
             objects.ARecordBase.create(connector,
-                                       ip='192.168.1.52',
-                                       view='view')
+                                       ipv4addr='192.168.1.52',
+                                       view='view', name='a_record')
 
         connector.get_object.assert_called_once_with(
             'record:a',
-            {'view': 'view', 'ipv4addr': '192.168.1.52'},
+            {'view': 'view', 'ipv4addr': '192.168.1.52', 'name': 'a_record'},
             return_fields=[])
 
     def test_update_fields_on_create(self):
         a_record = [{'_ref': 'record:a/Awsdrefsasdwqoijvoriibtrni',
-                     'ip': '192.168.1.52',
+                     'ipv4addr': '192.168.1.52',
                      'name': 'a_record',
                      'comment': 'test_comment'}]
         connector = self._mock_connector(get_object=a_record)
         objects.ARecordBase.create(connector,
-                                   ip='192.168.1.52',
+                                   ipv4addr='192.168.1.52',
                                    view='view',
                                    comment='new_test_comment',
                                    update_if_exists=True)
         connector.get_object.assert_called_once_with(
             'record:a',
-            {'view': 'view', 'ipv4addr': '192.168.1.52'},
+            {'view': 'view', 'ipv4addr': '192.168.1.52', 'name': 'a_record'},
             return_fields=[])
         connector.update_object.assert_called_once_with(
             a_record[0]['_ref'],
-            {'ipv4addr': '192.168.1.52', 'comment': 'new_test_comment'},
+            {'comment': 'new_test_comment', 'ipv4addr': '192.168.1.52',
+             'name': 'a_record'},
             mock.ANY)
 
     def test_update_fields_on_create_v6(self):
@@ -592,17 +600,20 @@ class TestObjects(unittest.TestCase):
                         'comment': "test_comment"}]
         connector = self._mock_connector(get_object=aaaa_record)
         objects.ARecordBase.create(connector,
-                                   ip='2001:610:240:22::c100:68b',
+                                   ipv6addr='2001:610:240:22::c100:68b',
                                    view='view',
+                                   name='aaaa_record',
                                    comment='new_test_comment',
                                    update_if_exists=True)
         connector.get_object.assert_called_once_with(
             'record:aaaa',
-            {'view': 'view', 'ipv6addr': '2001:610:240:22::c100:68b'},
+            {'view': 'view', 'ipv6addr': '2001:610:240:22::c100:68b',
+             'name': 'aaaa_record'},
             return_fields=[])
         connector.update_object.assert_called_once_with(
             aaaa_record[0]['_ref'],
-            {'comment': 'new_test_comment', 'ipv6addr': '2001:610:240:22::c100:68b'},
+            {'comment': 'new_test_comment',
+             'ipv6addr': '2001:610:240:22::c100:68b'},
             mock.ANY)
 
     def test_ip_version(self):
@@ -639,18 +650,18 @@ class TestObjects(unittest.TestCase):
         txt_record_copy = copy.deepcopy(mock_record)
         connector = self._mock_connector(create_object=txt_record_copy)
         txt = objects.TXTRecord.create(connector, name='text_test.my_zone.com',
-                                     text='hello_text',
-                                     view='my_dns_view')
+                                       text='hello_text',
+                                       view='my_dns_view')
         self.assertIsInstance(txt, objects.TXTRecord)
         connector.create_object.assert_called_once_with(
             'record:txt',
             {'name': 'text_test.my_zone.com',
              'text': 'hello_text',
-             'view': 'my_dns_view',
-            }, ['extattrs', 'name', 'text', 'view'])
+             'view': 'my_dns_view'}, ['extattrs', 'name', 'text', 'view'])
 
     def test_call_upload_file(self):
-        upload_file_path = '/http_direct_file_io/req_id-UPLOAD-0302163936014609/ibx_networks.csv'
+        upload_file_path = '/http_direct_file_io/' \
+                           'req_id-UPLOAD-0302163936014609/ibx_networks.csv'
         upload_url = 'https://infoblox.example.org' + upload_file_path
         self._create_infoblox_csv()
         with open('tests/ibx_networks.csv', 'r') as fh:
@@ -664,5 +675,3 @@ class TestObjects(unittest.TestCase):
         self.assertTrue(result)
         # clean up and remove csv file
         self._delete_infoblox_csv()
-
-

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -99,4 +99,3 @@ class TestUtils(unittest.TestCase):
             self.assertEqual(2, len(page))
             self.assertEqual(resp[i:i+max_results], page)
             i = i + max_results
-


### PR DESCRIPTION
# Issue/Feature description

* Exception InfobloxFetchGotMultipleObjects raised when mandate field FQDN not passed for zone creation

# How it was fixed/implemented

* Added required field check in objects.py file. Along with that fixed linting for unit tests.

