### PR TITLE
Changes as per bug NIOS-86124: Openstack version compatibility

### DIFF
--- a/infoblox_client/objects.py
+++ b/infoblox_client/objects.py
@@ -10909,7 +10909,8 @@ class Member(InfobloxObject):
                'use_traffic_capture_auth_dns', 'use_traffic_capture_chr',
                'use_traffic_capture_qps', 'use_traffic_capture_rec_dns',
                'use_traffic_capture_rec_queries', 'use_trap_notifications',
-               'use_v4_vrrp', 'vip_setting', 'vpn_mtu']
+               'use_v4_vrrp', 'vip_setting', 'vpn_mtu',
+               'ipv4addr', 'ipv6addr']
     _search_for_update_fields = ['config_addr_type', 'host_name', 'platform',
                                  'service_type_configuration']
     _updateable_search_fields = ['comment', 'config_addr_type', 'enable_ha',


### PR DESCRIPTION
# Issue/Feature description

* Fields ('ipv4addr', 'ipv6addr') are missing from 'class Member(InfobloxObject)' breaking backwards compatibility of Openstack Plugin.

# How it was fixed/implemented

* Added fields in the Objects.py file and fixed the generator file for the same.

