### PR TITLE
fixes issue #365

### DIFF
--- a/infoblox_client/connector.py
+++ b/infoblox_client/connector.py
@@ -374,8 +374,10 @@ class Connector(object):
     def download_file(self, url):
         if self.session.cookies:
             self.session.auth = None
+        ibapauth_cookie = self.session.cookies.get('ibapauth')
+        req_cookies = {'ibapauth': ibapauth_cookie}
         headers = {'content-type': 'application/force-download'}
-        r = self.session.get(url, headers=headers)
+        r = self.session.get(url, headers=headers, cookies=req_cookies)
         if r.status_code != requests.codes.ok:
             response = utils.safe_json_load(r.content)
             raise ib_ex.InfobloxFileDownloadFailed(


### PR DESCRIPTION
# Issue/Feature description

* cookies were not persisted in the session when attempting to call download_file() method on the connector

# How it was fixed/implemented

* grab session.cookies and get the `ibapauth` cookie and supply it as an arg to the download_file() call

# Tests

* script that was used in issue #365 was replayed w/ the fix

# Reviewers
