### PR TITLE
Fixed python version incompatibility in GH workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,13 +1,11 @@
 # Issue/Feature description
 
-* 
+*
 
 # How it was fixed/implemented
 
-* 
+*
 
 # Tests
 
-* 
-
-# Reviewers
+*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,10 +17,10 @@ jobs:
     timeout-minutes: 5
     steps:
         - uses: actions/checkout@v3
-        - name: Set up Python 3.6
+        - name: Set up Python 3.8
           uses: actions/setup-python@v3
           with:
-            python-version: '3.6'
+            python-version: '3.8'
         - name: Install dependencies
           run: |
             python -m pip install --upgrade pip
@@ -31,7 +31,7 @@ jobs:
             TOXENV: pep8
   test:
     name: Unit Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 15
     strategy:
       fail-fast: false
@@ -72,10 +72,10 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.6
+      - name: Set up Python 3.8
         uses: actions/setup-python@v3
         with:
-          python-version: '3.6'
+          python-version: '3.8'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,10 +2,6 @@
 # you can turn it on using a cron schedule for regular testing.
 name: Unit Tests
 on:
-  pull_request:
-    paths-ignore:
-      - 'README.md'
-      - 'docs/**'
   push:
     paths-ignore:
       - 'README.md'

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -176,7 +176,8 @@ class TestInfobloxConnector(unittest.TestCase):
                 return_fields=return_fields
             )
             patched_get.assert_called_once_with(
-                'https://infoblox.example.org/wapi/v1.1/network?%2ASubnet+ID=fake_subnet_id&_return_fields%2B=extattrs',  # noqa: E501
+                'https://infoblox.example.org/wapi/v1.1/network?%2ASubnet+ID=fake_subnet_id&_return_fields%2B=extattrs',
+                # noqa: E501
                 headers=self.connector.DEFAULT_HEADER,
                 timeout=self.default_opts.http_request_timeout,
                 verify=self.default_opts.ssl_verify,
@@ -197,7 +198,8 @@ class TestInfobloxConnector(unittest.TestCase):
                 return_fields=return_fields
             )
             patched_get.assert_called_once_with(
-                'https://infoblox.example.org/wapi/v1.1/network?%2ASubnet+ID=fake_subnet_id&_return_fields=extattrs',  # noqa: E501
+                'https://infoblox.example.org/wapi/v1.1/network?%2ASubnet+ID=fake_subnet_id&_return_fields=extattrs',
+                # noqa: E501
                 headers=self.connector.DEFAULT_HEADER,
                 timeout=self.default_opts.http_request_timeout,
                 verify=self.default_opts.ssl_verify,
@@ -340,14 +342,16 @@ class TestInfobloxConnector(unittest.TestCase):
                                             query_params=query_params,
                                             extattrs=ext_attrs)
         self.assertEqual(
-            'https://infoblox.example.org/wapi/v1.1/network?%2ASubnet+ID=fake_subnet_id&some_option=some_value',  # noqa: E501
+            'https://infoblox.example.org/wapi/v1.1/network?%2ASubnet+ID=fake_subnet_id&some_option=some_value',
+            # noqa: E501
             url)
 
     def test_construct_url_with_query_params_containing_array(self):
         query_params = {'array_option': ['value1', 'value2']}
         url = self.connector._construct_url('network',
                                             query_params=query_params)
-        self.assertEqual('https://infoblox.example.org/wapi/v1.1/network?array_option=value1&array_option=value2',  # noqa: E501
+        self.assertEqual('https://infoblox.example.org/wapi/v1.1/network?array_option=value1&array_option=value2',
+                         # noqa: E501
                          url)
 
     def test_construct_url_with_force_proxy(self):
@@ -355,7 +359,8 @@ class TestInfobloxConnector(unittest.TestCase):
         url = self.connector._construct_url('network',
                                             extattrs=ext_attrs,
                                             force_proxy=True)
-        self.assertEqual('https://infoblox.example.org/wapi/v1.1/network?%2ASubnet+ID=fake_subnet_id&_proxy_search=GM',  # noqa: E501
+        self.assertEqual('https://infoblox.example.org/wapi/v1.1/network?%2ASubnet+ID=fake_subnet_id&_proxy_search=GM',
+                         # noqa: E501
                          url)
 
     def test_get_object_with_proxy_flag(self):
@@ -370,8 +375,7 @@ class TestInfobloxConnector(unittest.TestCase):
                                                          {},
                                                          None,
                                                          force_proxy=True)
-        self.connector._get_object.called_with('network',
-                                               self.connector._construct_url)
+        self.connector._get_object.assert_called_with('network', mock.ANY)
 
     def test_get_object_without_proxy_flag(self):
         self.connector._get_object = mock.MagicMock(

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ deps =
     -rtesting_requirements.txt
 setenv =
 passenv = *
+allowlist_externals = mkdir
 whitelist_externals=mkdir
 commands =
     mkdir -p {[setup]results}

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,6 @@ deps =
 setenv =
 passenv = *
 allowlist_externals = mkdir
-whitelist_externals=mkdir
 commands =
     mkdir -p {[setup]results}
     nosetests tests \


### PR DESCRIPTION
# Issue/Feature description

* Python 3.6 has reached EoL and no longer supported by ubuntu-latest runner.

# How it was fixed/implemented

* For matrix test with tox, changed Ubuntu version to 20.04, since matrix test still needs a python versions <= 3.6.

* For lint and sphinx jobs, updated python version to 3.8.

* See https://github.com/actions/setup-python/issues/544#issuecomment-1332535877
