### PR TITLE
drop "six" Python2+3 shim usage

### DIFF
--- a/infoblox_client/connector.py
+++ b/infoblox_client/connector.py
@@ -17,7 +17,6 @@ import functools
 import re
 import urllib
 import requests
-import six
 import urllib3
 import time
 from requests import exceptions as req_exc
@@ -725,7 +724,7 @@ class Connector(object):
         Raises:
             ValueError: if an invalid version is passed
         """
-        valid = wapi_version and isinstance(wapi_version, six.string_types)
+        valid = wapi_version and isinstance(wapi_version, str)
         if not valid:
             raise ValueError("Invalid argument was passed")
         version_match = re.search(r'(\d+)\.(\d+)', wapi_version)

--- a/infoblox_client/feature.py
+++ b/infoblox_client/feature.py
@@ -13,8 +13,6 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import six
-
 from infoblox_client import exceptions as ib_ex
 
 FEATURE_VERSIONS = {
@@ -42,7 +40,7 @@ class Feature(object):
         if feature_versions is None:
             feature_versions = FEATURE_VERSIONS
 
-        if isinstance(version, six.string_types):
+        if isinstance(version, str):
             wapi_version = version
         elif hasattr(version, 'wapi_version'):
             wapi_version = getattr(version, 'wapi_version')

--- a/infoblox_client/objects.py
+++ b/infoblox_client/objects.py
@@ -12,7 +12,6 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
-import six
 
 try:
     from oslo_log import log as logging
@@ -546,7 +545,7 @@ class IP(SubObjects):
             return IPv4(ip=ip, mac=mac, **kwargs)
 
     def __eq__(self, other):
-        if isinstance(other, six.string_types):
+        if isinstance(other, str):
             return self.ip == other
         elif isinstance(other, self.__class__):
             return self.ip == other.ip
@@ -14341,7 +14340,7 @@ class HostRecordV4(HostRecord):
             ipXaddr is also filled to be able perform search on NIOS
             and verify that no such host record exists yet.
         """
-        if isinstance(ips, six.string_types):
+        if isinstance(ips, str):
             setattr(self, ipaddr_name, ips)
         elif isinstance(ips, (list, tuple)) and isinstance(ips[0], IP):
             setattr(self, ipaddr_name, ips[0].ip)
@@ -14496,7 +14495,7 @@ class HostRecordV6(HostRecord):
             ipXaddr is also filled to be able perform search on NIOS
             and verify that no such host record exists yet.
         """
-        if isinstance(ips, six.string_types):
+        if isinstance(ips, str):
             setattr(self, ipaddr_name, ips)
         elif isinstance(ips, (list, tuple)) and isinstance(ips[0], IP):
             setattr(self, ipaddr_name, ips[0].ip)

--- a/infoblox_client/utils.py
+++ b/infoblox_client/utils.py
@@ -14,7 +14,6 @@
 #    under the License.
 
 import netaddr
-import six
 import re
 
 try:
@@ -48,7 +47,7 @@ def generate_duid(mac):
 
     0x00 + mac with last 3 hex + mac with 6 hex
     """
-    valid = mac and isinstance(mac, six.string_types)
+    valid = mac and isinstance(mac, str)
     if not valid:
         raise ValueError("Invalid argument was passed")
     return "00:" + mac[9:] + ":" + mac

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-six>=1.11.0
 requests>=2.5.2
 urllib3>=1.13
 oslo.serialization>=1.4.0

--- a/tests/test_object_manager.py
+++ b/tests/test_object_manager.py
@@ -15,7 +15,6 @@
 
 import unittest
 import mock
-import six
 
 from infoblox_client import exceptions
 from infoblox_client import object_manager as om
@@ -31,7 +30,7 @@ class PayloadMatcher(object):
     def __eq__(self, actual):
         expected = []
 
-        for key, expected_value in six.iteritems(self.args):
+        for key, expected_value in self.args.items():
             expected.append(self._verify_value_is_expected(actual, key,
                                                            expected_value))
 


### PR DESCRIPTION
this project does not support Python 2 anymore

# Issue/Feature description

* Drop old Python 2+3 compatibility shim

# How it was fixed/implemented

* as usual ... https://wiki.debian.org/Python3-six-removal

# Tests

* pyflakes
